### PR TITLE
Rectified bug that would cause crash if stackFrames called without apply_dq argument

### DIFF
--- a/gempy/gemini/eti/gemcombineparam.py
+++ b/gempy/gemini/eti/gemcombineparam.py
@@ -86,7 +86,7 @@ class Masktype(GemcombineParam):
     def __init__(self, inputs=None, params=None):
         log.debug("Masktype __init__")
         GemcombineParam.__init__(self, inputs, params)
-        if params["apply_dq"]:
+        if params.get("apply_dq"):
             self.masktype = "goodvalue"
         else:
             self.masktype = "none"


### PR DESCRIPTION
The provided default parameters for GHOST slit frame stacking failed
to provide a default value for the apply_dq option to stackFrames (this
has now been fixed). This resulted in the RecipeSystem crashing at the
line modified in this commit, as the key 'apply_dq' did not exist in
the params dictionary. The new get call will return None if the key is
not defined (although as good practice, it probably should be anyway).