### PR TITLE
Fix/reduce keep output filenames

### DIFF
--- a/geminidr/f2/test/rsys.cfg
+++ b/geminidr/f2/test/rsys.cfg
@@ -1,3 +1,0 @@
-[calibs]
-standalone = True
-database_dir = $TEST_PATH/F2/

--- a/geminidr/f2/test/test_reduce.py
+++ b/geminidr/f2/test/test_reduce.py
@@ -36,7 +36,6 @@ def caldb():
     yield calibration_service
 
 
-@pytest.mark.skip('I want to go to green state as quick as possible')
 def test_reduce_image(test_path, caldb):
 
     all_files = glob.glob(

--- a/geminidr/f2/test/test_reduce.py
+++ b/geminidr/f2/test/test_reduce.py
@@ -7,6 +7,11 @@ import os
 from gempy.adlibrary import dataselect
 from recipe_system.reduction.coreReduce import Reduce
 
+from gempy.utils import logutils
+
+
+logutils.config(file_name='dummy.log')
+
 
 @pytest.fixture
 def test_path():
@@ -23,20 +28,34 @@ def test_path():
 
 
 @pytest.fixture(scope='module')
-def caldb():
+def caldb(request):
 
     from recipe_system.cal_service import set_calservice, CalibrationService
 
+    caldb_folder = os.path.dirname(__file__)
+    caldb_configuration_file = 'rsys.cfg'
+
+    with open(caldb_configuration_file, 'w') as buffer:
+
+        buffer.write(
+            "[calibs]\n"
+            "standalone = True\n"
+            "database_dir = {:s}".format(caldb_folder)
+        )
+
     calibration_service = CalibrationService()
-    calibration_service.config()
+    calibration_service.config(db_dir=caldb_folder)
     calibration_service.init(wipe=True)
 
     set_calservice()
 
-    yield calibration_service
+    return calibration_service
 
 
 def test_reduce_image(test_path, caldb):
+
+    caldb.config()
+    caldb.init(wipe=True)
 
     all_files = glob.glob(
         os.path.join(test_path, 'F2/test_reduce/', '*.fits'))
@@ -72,6 +91,8 @@ def test_reduce_image(test_path, caldb):
 
         reduce_darks.runr()
 
+        caldb.add_cal(reduce_darks.output_filenames[0])
+
     reduce_bpm = Reduce()
     reduce_bpm.files.extend(flats)
     reduce_bpm.files.extend(darks_3s)
@@ -85,10 +106,15 @@ def test_reduce_image(test_path, caldb):
     reduce_flats.uparms = [('addDQ:user_bpm', bpm_filename)]
     reduce_flats.runr()
 
+    caldb.add_cal(reduce_flats.output_filenames[0])
+
     reduce_target = Reduce()
     reduce_target.files.extend(science)
     reduce_target.uparms = [('addDQ:user_bpm', bpm_filename)]
     reduce_target.runr()
+
+    for f in caldb.list_files():
+        print(f)
 
 
 if __name__ == '__main__':

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -217,8 +217,8 @@ class Reduce(object):
                 log.error(str(err))
                 xstat = signal.SIGABRT
 
-
         self._write_final(p.streams['main'])
+        self.output_filenames = [ad.filename for ad in p.streams['main']]
 
         if xstat != 0:
             msg = "reduce instance aborted."


### PR DESCRIPTION
At some point,  `reduce` lost the reference to the output files. This is required for the F2 tests. Fixed and it was hanging around. Now it is solved, we can merge. PR will trigger CI tests before merging.