### PR TITLE
Test displaying new jenkins reports

### DIFF
--- a/.jenkins/test_env_and_install_missing_libs.sh
+++ b/.jenkins/test_env_and_install_missing_libs.sh
@@ -16,8 +16,3 @@ cd -
 cd .jenkins
 pip install --quiet GeminiCalMgr-0.9.11-py3-none-any.whl
 cd -
-
-mkdir -p ${HOME}/.geminidr
-cp recipe_system/cal_service/tests/rsys.cfg ${HOME}/.geminidr
-cd -
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,10 @@ pipeline {
                     '''
             }
             post {
-                echo 'Report pyLint warnings using the warnings-ng-plugin'
-                recordIssues enabledForFailure: true, tool: pyLint(pattern: '**/reports/pylint.log')
+                always {
+                    echo 'Report pyLint warnings using the warnings-ng-plugin'
+                    recordIssues enabledForFailure: true, tool: pyLint(pattern: '**/reports/pylint.log')
+                }
             }
         }
 
@@ -140,32 +142,10 @@ pipeline {
                 }
             }
         }
-
-        stage('Build package') {
-            when {
-                expression {
-                    currentBuild.result == null || currentBuild.result == 'SUCCESS'
-                }
-            }
-            steps {
-                sh  '''
-                    source activate ${BUILD_TAG}
-                    python setup.py sdist bdist_egg
-                    '''
-            }
-            post {
-                always {
-                    // Archive unit tests for the future
-                    archiveArtifacts (allowEmptyArchive: true,
-                        artifacts: 'dist/*whl',
-                        fingerprint: true)
-                }
-            }
-        }
     }
     post {
         always {
-            sh 'conda remove --yes --all --quiet -n ${BUILD_TAG}'
+            sh 'conda remove --quiet --yes --all -n ${BUILD_TAG}'
         }
         failure {
             echo "Send e-mail, when failed"

--- a/geminidr/f2/test/test_reduce.py
+++ b/geminidr/f2/test/test_reduce.py
@@ -49,12 +49,13 @@ def caldb(request):
     calibration_service.config(config_file=caldb_conf_file)
     calibration_service.init(wipe=True)
 
-    return calibration_service
+    yield calibration_service
+
+    os.remove(caldb_conf_file)
 
 
 def test_reduce_image(test_path, caldb):
 
-    caldb.config()
     caldb.init(wipe=True)
 
     all_files = glob.glob(

--- a/geminidr/gsaoi/test/test_reduce.py
+++ b/geminidr/gsaoi/test/test_reduce.py
@@ -54,7 +54,6 @@ def caldb(request):
 
 def test_reduce_image(test_path, caldb):
 
-    caldb.config()
     caldb.init(wipe=True)
 
     all_files = glob.glob(


### PR DESCRIPTION
Adds reports using the [warnings-ng-plugin](https://jenkins.io/doc/pipeline/steps/warnings-ng/) for PyLint and PyDocStyle. Also fixes the bug related with the calibration service that made the tests to look for the `fitsstorage` instead of using the local database.