### PR TITLE
Stacking: fix debug_pixel and add log message

### DIFF
--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -213,7 +213,7 @@ class Stack(PrimitivesBASE):
                 target = np.mean(levels[0])
                 if scale:
                     scale_factors = np.tile(target / np.mean(levels, axis=1),
-                                              num_ext).reshape(num_ext, num_img)
+                                            num_ext).reshape(num_ext, num_img)
                 else:  # zero=True
                     zero_offsets = np.tile(target - np.mean(levels, axis=1),
                                            num_ext).reshape(num_ext, num_img)
@@ -236,6 +236,9 @@ class Stack(PrimitivesBASE):
                         " extensions have no variance. 'sigclip' will be used"
                         " instead.")
             reject_method = "sigclip"
+
+        log.stdinfo("Combining {} inputs with {} and {} rejection"
+                    .format(num_img, params["operation"], reject_method))
 
         stack_function = NDStacker(combine=params["operation"],
                                    reject=reject_method,

--- a/gempy/library/nddops.py
+++ b/gempy/library/nddops.py
@@ -274,12 +274,9 @@ class NDStacker:
 
         # Convert the debugging pixel to (x,y) coords and bounds check
         if self._debug_pixel is not None:
-            pixel_coords = []
-            for length in reversed(data.shape[1:-1]):
-                pixel_coords.append(self._debug_pixel % length)
-                self._debug_pixel //= length
-            self._debug_pixel = tuple(reversed(pixel_coords + [self._debug_pixel]))
-            if self._debug_pixel[0] > data.shape[1]:
+            try:
+                self._debug_pixel = np.unravel_index(self._debug_pixel, data.shape[1:])
+            except ValueError:
                 self._logmsg("Debug pixel out of range")
                 self._debug_pixel = None
             else:


### PR DESCRIPTION
While debugging a stacking issue, I found that it would be useful to have more info about the staking algorithm that is used, and also I had some trouble to use the `debug_pixel` option. With `np.unravel_index` I get what I expect. cc @chris-simpson 