### PR TITLE
Refactor Astrodata

### DIFF
--- a/astrodata/__init__.py
+++ b/astrodata/__init__.py
@@ -7,13 +7,13 @@ accordingly to the :class:`~astrodata.TagSet` received.
 
 __all__ = ['AstroData', 'AstroDataError', 'TagSet', 'NDAstroData',
            'astro_data_descriptor', 'astro_data_tag', 'keyword',
-           'open', 'create', '__version__', 'version']
+           'open', 'create', '__version__', 'version', 'add_header_to_table']
 
 
-from .core import AstroData, AstroDataError, AstroDataFits
+from .core import AstroData, AstroDataFits
 # TODO: Remove 'write' when there's nothing else using it
 from .fits import KeywordCallableWrapper, add_header_to_table
-from .factory import AstroDataFactory
+from .factory import AstroDataFactory, AstroDataError
 from .nddata import NDAstroData
 from .utils import *
 from ._version import version

--- a/astrodata/__init__.py
+++ b/astrodata/__init__.py
@@ -2,7 +2,7 @@
 This package add another abstraction layer to astronomical data by parsing
 the information contained in the headers as attributes. To do so,
 one must subclass :class:`astrodata.AstroData` and add parse methods
-accordingly to the :class:`~astrodata.core.TagSet` received.
+accordingly to the :class:`~astrodata.TagSet` received.
 """
 
 __all__ = ['AstroData', 'AstroDataError', 'TagSet', 'NDAstroData',
@@ -10,7 +10,7 @@ __all__ = ['AstroData', 'AstroDataError', 'TagSet', 'NDAstroData',
            'open', 'create', '__version__', 'version']
 
 
-from .core import *
+from .core import AstroData, AstroDataError, AstroDataFits
 # TODO: Remove 'write' when there's nothing else using it
 from .fits import KeywordCallableWrapper, add_header_to_table
 from .factory import AstroDataFactory

--- a/astrodata/__init__.py
+++ b/astrodata/__init__.py
@@ -15,6 +15,7 @@ from .core import *
 from .fits import KeywordCallableWrapper, add_header_to_table
 from .factory import AstroDataFactory
 from .nddata import NDAstroData
+from .utils import *
 from ._version import version
 
 __version__ = version()

--- a/astrodata/__init__.py
+++ b/astrodata/__init__.py
@@ -12,7 +12,7 @@ __all__ = ['AstroData', 'AstroDataError', 'TagSet', 'NDAstroData',
 
 from .core import *
 # TODO: Remove 'write' when there's nothing else using it
-from .fits import AstroDataFits, KeywordCallableWrapper, add_header_to_table
+from .fits import KeywordCallableWrapper, add_header_to_table
 from .factory import AstroDataFactory
 from .nddata import NDAstroData
 from ._version import version

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -152,8 +152,6 @@ class AstroData:
         """
         for cls in self.__class__.mro():
             with suppress(AttributeError, KeyError):
-                # FIXME: replace with _keyword_dict, unless there is a good
-                # reason why we need mangling ?
                 mangled_dict_name = '_{}__keyword_dict'.format(cls.__name__)
                 return getattr(self, mangled_dict_name)[name]
         else:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -9,6 +9,7 @@ from functools import partial, wraps
 import numpy as np
 
 from astropy.io import fits
+from astropy.table import Table
 
 from .nddata import NDAstroData as NDDataObject, ADVarianceUncertainty
 from .utils import deprecated, normalize_indices
@@ -421,7 +422,7 @@ class AstroData:
         If this data provider represents a single slice out of a whole dataset,
         return True. Otherwise, return False.
         """
-        return len(self.nddata) == 1
+        return self._indices is not None and len(self._indices) == 1
 
     def is_settable(self, attr):
         """
@@ -735,7 +736,10 @@ class AstroData:
         --------
         A non-negative integer.
         """
-        return len(self.nddata)
+        if self._indices is not None:
+            return len(self._indices)
+        else:
+            return len(self._nddata)
 
     def append(self, ext, name=None, **kwargs):
         """
@@ -795,6 +799,61 @@ class AstroData:
 
         """
         return self._exposed.copy()
+
+    def _pixel_info(self, indices):
+        for idx, obj in ((n, self._nddata[k]) for n, k in enumerate(indices)):
+            other_objects = []
+            uncer = obj.uncertainty
+            fixed = (('variance', None if uncer is None else uncer),
+                     ('mask', obj.mask))
+            for name, other in fixed + tuple(sorted(obj.meta['other'].items())):
+                if other is not None:
+                    if isinstance(other, Table):
+                        other_objects.append(dict(
+                            attr=name, type='Table',
+                            dim=str((len(other), len(other.columns))),
+                            data_type='n/a'
+                        ))
+                    else:
+                        dim = ''
+                        if hasattr(other, 'dtype'):
+                            dt = other.dtype.name
+                            dim = str(other.shape)
+                        elif hasattr(other, 'data'):
+                            dt = other.data.dtype.name
+                            dim = str(other.data.shape)
+                        elif hasattr(other, 'array'):
+                            dt = other.array.dtype.name
+                            dim = str(other.array.shape)
+                        else:
+                            dt = 'unknown'
+                        other_objects.append(dict(
+                            attr=name,
+                            type=type(other).__name__,
+                            dim=dim,
+                            data_type=dt
+                        ))
+
+            yield dict(
+                idx='[{:2}]'.format(idx),
+                main=dict(
+                    content='science',
+                    type=type(obj).__name__,
+                    dim='({})'.format(', '.join(str(s) for s in obj.data.shape)),
+                    data_type=obj.data.dtype.name
+                ),
+                other=other_objects
+            )
+
+    def _other_info(self):
+        # NOTE: This covers tables, only. Study other cases before
+        # implementing a more general solution
+        if self._tables:
+            for name, table in sorted(self._tables.items()):
+                if type(table) is list:
+                    # This is not a free floating table
+                    continue
+                yield (name, 'Table', (len(table), len(table.columns)))
 
     def info(self):
         """

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -26,12 +26,12 @@ NO_DEFAULT = object()
 
 
 _arit_doc = """
-    Performs {name} by evaluating ``self`` {op} ``operand``.
+    Performs {name} by evaluating ``self {op} operand``.
 
     Parameters
     ----------
     oper : number or object
-        The operand to perform the operation  ``self`` {op} ``operand``.
+        The operand to perform the operation  ``self {op} operand``.
 
     Returns
     --------

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -524,9 +524,8 @@ class AstroData:
             If `idx` is out of range.
 
         """
-        if self._indices:
+        if self.is_sliced:
             raise TypeError("Can't remove items from a sliced object")
-        # FIXME: what happens with indices/slices ?
         del self._nddata[idx]
 
     def __getattr__(self, attribute):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -666,6 +666,7 @@ class AstroData:
                              indices=indices)
         obj._path = self.path
         obj._orig_filename = self.orig_filename
+        obj._exposed = self._exposed
         return obj
 
     def __delitem__(self, idx):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -198,13 +198,13 @@ class AstroData:
         'ut_date': 'DATE-OBS'
     }
 
-    def __init__(self, nddatas=None, other=None, phu=None, indices=None):
-        if nddatas is None:
-            nddatas = []
-        if not isinstance(nddatas, (list, tuple)):
-            nddatas = list(nddatas)
+    def __init__(self, nddata=None, other=None, phu=None, indices=None):
+        if nddata is None:
+            nddata = []
+        if not isinstance(nddata, (list, tuple)):
+            nddata = list(nddata)
 
-        self._nddata = nddatas
+        self._nddata = nddata
         self._other = other
         self._phu = phu or fits.Header()
         self._indices = indices
@@ -638,7 +638,9 @@ class AstroData:
         if self._indices:
             # FIXME: slice _indices
             pass
-        return self.__class__(self.nddatas, other=self.other, phu=self.phu,
+        return self.__class__(self.nddata,
+                              # other=self.other,
+                              phu=self.phu,
                               indices=indices)
 
     def __delitem__(self, idx):
@@ -681,11 +683,8 @@ class AstroData:
         AttributeError
             If the attribute could not be found/computed.
         """
-        try:
-            return getattr(self._dataprov, attribute)
-        except AttributeError:
-            raise AttributeError("{!r} object has no attribute {!r}"
-                                 .format(self.__class__.__name__, attribute))
+        raise AttributeError("{!r} object has no attribute {!r}"
+                             .format(self.__class__.__name__, attribute))
 
     def __setattr__(self, attribute, value):
         """
@@ -1321,7 +1320,7 @@ class AstroData:
             illegal somehow.
 
         """
-        if not self.is_single:
+        if self.is_sliced and not self.is_single:
             # TODO: We could rethink this one, but leave it like that at
             # the moment
             raise TypeError("Can't append objects to non-single slices")

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -13,6 +13,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.table import Table
+from astropy.utils import format_doc
 
 from .fits import (DEFAULT_EXTENSION, FitsHeaderCollection, _process_table,
                    read_fits, write_fits)
@@ -25,6 +26,20 @@ NO_DEFAULT = object()
 
 class AstroDataError(Exception):
     pass
+
+
+_arit_doc = """
+    Performs {name} by evaluating ``self`` {op} ``operand``.
+
+    Parameters
+    ----------
+    oper : number or object
+        The operand to perform the operation  ``self`` {op} ``operand``.
+
+    Returns
+    --------
+    `AstroData` instance
+"""
 
 
 class AstroData:
@@ -782,135 +797,47 @@ class AstroData:
         return self._oper(partial(fn, handle_mask=np.bitwise_or,
                                   handle_meta='first_found'), operand)
 
+    @format_doc(_arit_doc, name='addition', op='+')
     def __add__(self, oper):
-        """
-        Implements the binary arithmetic operation ``+``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be added to this instance.
-
-        Returns
-        --------
-        A new `AstroData` instance
-        """
         copy = deepcopy(self)
         copy += oper
         return copy
 
+    @format_doc(_arit_doc, name='subtraction', op='-')
     def __sub__(self, oper):
-        """
-        Implements the binary arithmetic operation ``-``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be subtracted to this instance.
-
-        Returns
-        --------
-        A new `AstroData` instance
-        """
         copy = deepcopy(self)
         copy -= oper
         return copy
 
+    @format_doc(_arit_doc, name='multiplication', op='*')
     def __mul__(self, oper):
-        """
-        Implements the binary arithmetic operation ``*``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be multiplied to this instance.
-
-        Returns
-        --------
-        A new `AstroData` instance
-        """
         copy = deepcopy(self)
         copy *= oper
         return copy
 
+    @format_doc(_arit_doc, name='division', op='/')
     def __truediv__(self, oper):
-        """
-        Implements the binary arithmetic operation ``/``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be divided to this instance.
-
-        Returns
-        --------
-        A new `AstroData` instance
-        """
         copy = deepcopy(self)
         copy /= oper
         return copy
 
+    @format_doc(_arit_doc, name='inplace addition', op='+=')
     def __iadd__(self, oper):
-        """
-        Implements the augmented arithmetic assignment ``+=``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be added to this instance.
-
-        Returns
-        --------
-        ``self``
-        """
         self._standard_nddata_op(NDDataObject.add, oper)
         return self
 
+    @format_doc(_arit_doc, name='inplace subtraction', op='-=')
     def __isub__(self, oper):
-        """
-        Implements the augmented arithmetic assignment ``-=``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be subtracted to this instance.
-
-        Returns
-        --------
-        ``self``
-        """
         self._standard_nddata_op(NDDataObject.subtract, oper)
         return self
 
+    @format_doc(_arit_doc, name='inplace multiplication', op='*=')
     def __imul__(self, oper):
-        """
-        Implements the augmented arithmetic assignment ``*=``.
-
-        Parameters
-        ----------
-        oper : number or object
-            The operand to be multiplied to this instance.
-
-        Returns
-        --------
-        ``self``
-        """
         self._standard_nddata_op(NDDataObject.multiply, oper)
         return self
 
+    @format_doc(_arit_doc, name='inplace division', op='/=')
     def __itruediv__(self, oper):
-        """
-        Implements the augmented arithmetic assignment ``/=``.
-
-        Parameters
-        ----------
-        oper : number or other
-            The operand to be divided to this instance.
-
-        Returns
-        --------
-        ``self``
-        """
         self._standard_nddata_op(NDDataObject.divide, oper)
         return self
 
@@ -931,12 +858,9 @@ class AstroData:
         return NDDataObject.divide(operand, ndd)
 
     def __rtruediv__(self, oper):
-        copy = deepcopy(self)
-        # copy._dataprov.__rtruediv__(oper)
-        copy._oper(copy._rdiv, oper)
-        # FIXME: check this, from FitsProviderProxy
-        # self._provider._oper(self._provider._rdiv, operand, self._mapping)
-        return copy
+        obj = deepcopy(self)
+        obj._oper(obj._rdiv, oper)
+        return obj
 
     def _reset_ver(self, nd):
         try:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -188,10 +188,10 @@ class AstroData:
         The data that will be manipulated through the `AstroData` instance.
     """
 
-    # Derived classes may provide their own _keyword_dict. Being a private
+    # Derived classes may provide their own __keyword_dict. Being a private
     # variable, each class will preserve its own, and there's no risk of
     # overriding the whole thing
-    _keyword_dict = {
+    __keyword_dict = {
         'instrument': 'INSTRUME',
         'object': 'OBJECT',
         'telescope': 'TELESCOP',
@@ -290,10 +290,12 @@ class AstroData:
         AttributeError
             If there is no keyword for the specified ``name``
         """
-
         for cls in self.__class__.mro():
             with suppress(AttributeError, KeyError):
-                return self._keyword_dict[name]
+                # FIXME: replace with _keyword_dict, unless there is a good
+                # reason why we need mangling ?
+                mangled_dict_name = '_{}__keyword_dict'.format(cls.__name__)
+                return getattr(self, mangled_dict_name)[name]
         else:
             raise AttributeError("No match for '{}'".format(name))
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -8,6 +8,8 @@ from functools import wraps
 
 from astropy.io import fits
 
+NO_DEFAULT = object()
+
 
 class TagSet(namedtuple('TagSet', 'add remove blocked_by blocks if_present')):
     """
@@ -175,9 +177,6 @@ class AstroData:
     provider : DataProvider
         The data that will be manipulated through the `AstroData` instance.
     """
-
-    # Simply a value that nobody is going to try to set an NDData attribute to
-    _IGNORE = -23
 
     # Derived classes may provide their own _keyword_dict. Being a private
     # variable, each class will preserve its own, and there's no risk of
@@ -878,7 +877,7 @@ class AstroData:
             if ext.variance is not None:
                 ext.variance = operator(ext.variance, *args, **kwargs)
 
-    def reset(self, data, mask=_IGNORE, variance=_IGNORE, check=True):
+    def reset(self, data, mask=NO_DEFAULT, variance=NO_DEFAULT, check=True):
         """
         Sets the .data, and optionally .mask and .variance attributes of a
         single-extension AstroData slice. This function will optionally
@@ -925,7 +924,7 @@ class AstroData:
         except AttributeError:
             if mask is None:
                 self.mask = mask
-            elif mask == self._IGNORE:
+            elif mask == NO_DEFAULT:
                 if hasattr(data, 'mask'):
                     self.mask = data.mask
             else:
@@ -939,7 +938,7 @@ class AstroData:
         except AttributeError:
             if variance is None:
                 self.uncertainty = None
-            elif variance == self._IGNORE:
+            elif variance == NO_DEFAULT:
                 if hasattr(data, 'uncertainty'):
                     self.uncertainty = data.uncertainty
             else:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -3,6 +3,7 @@ import os
 import re
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
+from contextlib import suppress
 from copy import deepcopy
 from functools import wraps
 
@@ -443,10 +444,10 @@ class AstroData:
     # Simply a value that nobody is going to try to set an NDData attribute to
     _IGNORE = -23
 
-    # Derived classes may provide their own __keyword_dict. Being a private
+    # Derived classes may provide their own _keyword_dict. Being a private
     # variable, each class will preserve its own, and there's no risk of
     # overriding the whole thing
-    __keyword_dict = {
+    _keyword_dict = {
         'instrument': 'INSTRUME',
         'object': 'OBJECT',
         'telescope': 'TELESCOP',
@@ -500,15 +501,12 @@ class AstroData:
         """
 
         for cls in self.__class__.mro():
-            mangled_dict_name = '_{}__keyword_dict'.format(cls.__name__)
-            try:
-                return getattr(self, mangled_dict_name)[name]
-            except (AttributeError, KeyError):
-                pass
+            with suppress(AttributeError, KeyError):
+                return self._keyword_dict[name]
         else:
             raise AttributeError("No match for '{}'".format(name))
 
-    def __process_tags(self):
+    def _process_tags(self):
         """
         Determines the tag set for the current instance
 
@@ -567,7 +565,7 @@ class AstroData:
         """
         A set of strings that represent the tags defining this instance
         """
-        return self.__process_tags()
+        return self._process_tags()
 
     @property
     def descriptors(self):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -787,10 +787,11 @@ class AstroData:
         """
         Implements attribute removal. If `self` represents a single slice, the
         """
+        if not attribute.isupper():
+            super().__delattr__(attribute)
+            return
+
         if self.is_sliced:
-            if not attribute.isupper():
-                raise ValueError("Can't delete non-capitalized attributes "
-                                 "from slices")
             if not self.is_single:
                 raise TypeError("Can't delete attributes on non-single slices")
 
@@ -807,15 +808,12 @@ class AstroData:
         else:
             # TODO: So far we're only deleting tables by name.
             #       Figure out what to do with aliases
-            if attribute.isupper():
-                if attribute in self._tables:
-                    del self._tables[attribute]
-                else:
-                    raise AttributeError(
-                        "'{}' is not a global table for this instance"
-                        .format(attribute))
+            if attribute in self._tables:
+                del self._tables[attribute]
             else:
-                super().__delattr__(attribute)
+                raise AttributeError(
+                    "'{}' is not a global table for this instance"
+                    .format(attribute))
 
     def __contains__(self, attribute):
         """

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1,7 +1,8 @@
 import inspect
+import logging
 import os
 import re
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from contextlib import suppress
 from copy import deepcopy
 from functools import partial, wraps
@@ -9,9 +10,12 @@ from functools import partial, wraps
 import numpy as np
 
 from astropy.io import fits
+from astropy.nddata import NDData
 from astropy.table import Table
 
-from .nddata import NDAstroData as NDDataObject, ADVarianceUncertainty
+from .fits import DEFAULT_EXTENSION, _process_table, read_fits, write_fits
+from .nddata import ADVarianceUncertainty
+from .nddata import NDAstroData as NDDataObject
 from .utils import deprecated, normalize_indices
 
 NO_DEFAULT = object()
@@ -194,9 +198,12 @@ class AstroData:
         'ut_date': 'DATE-OBS'
     }
 
-    def __init__(self, nddatas, other=None, phu=None, indices=None):
-        if isinstance(nddatas, (list, tuple)):
-            nddatas = dict(zip(range(len(nddatas)), nddatas))
+    def __init__(self, nddatas=None, other=None, phu=None, indices=None):
+        if nddatas is None:
+            nddatas = []
+        if not isinstance(nddatas, (list, tuple)):
+            nddatas = list(nddatas)
+
         self._nddata = nddatas
         self._other = other
         self._phu = phu or fits.Header()
@@ -205,6 +212,7 @@ class AstroData:
         self._exposed = set()
         self._fixed_settable = {'data', 'uncertainty', 'mask', 'variance',
                                 'wcs', 'path', 'filename'}
+        self._logger = logging.getLogger(__name__)
         self._orig_filename = None
         self._path = None
         self._processing_tags = False
@@ -450,6 +458,10 @@ class AstroData:
         else:
             ndd = self._nddata
         return ndd[0] if self.is_single else ndd
+
+    def table(self):
+        # FIXME: do we need this in addition to .tables ?
+        return self._tables.copy()
 
     @property
     def tables(self):
@@ -740,49 +752,6 @@ class AstroData:
             return len(self._indices)
         else:
             return len(self._nddata)
-
-    def append(self, ext, name=None, **kwargs):
-        """
-        Adds a new top-level extension. Objects appended to a single
-        slice will actually be made hierarchically dependent of the science
-        object represented by that slice. If appended to the provider as
-        a whole, the new member will be independent (eg. global table, new
-        science object).
-
-        Args
-        -----
-        ext : array, `NDData`, `Table`, other
-            The contents for the new extension. The exact accepted types depend
-            on the class implementing this interface. Implementations specific
-            to certain data formats may accept specialized types (eg. a FITS
-            provider will accept an `ImageHDU` and extract the array out of it)
-
-        name : str, optional
-            A name that may be used to access the new object, as an attribute
-            of the provider. The name is typically ignored for top-level
-            (global) objects, and required for the others. If the name cannot
-            be derived from the metadata associated to `extension`, you will
-            have to provider one.
-
-            It can consist in a combination of numbers and letters, with the
-            restriction that the letters have to be all capital, and the first
-            character cannot be a number ("[A-Z][A-Z0-9]*").
-
-        Returns
-        --------
-        The same object, or a new one, if it was necessary to convert it to
-        a more suitable format for internal use.
-
-        Raises
-        -------
-        TypeError
-            If adding the object in an invalid situation (eg. `name` is `None`
-            when adding to a single slice)
-        ValueError
-            Raised if the extension is of a proper type, but its value is
-            illegal somehow.
-
-        """
 
     @property
     def exposed(self):
@@ -1092,12 +1061,278 @@ class AstroData:
         copy._oper(copy._rdiv, oper)
         return copy
 
+    def _reset_ver(self, nd):
+        try:
+            ver = max(_nd.meta['ver'] for _nd in self._nddata) + 1
+        except ValueError:
+            # This seems to be the first extension!
+            ver = 1
+
+        nd.meta['header']['EXTVER'] = ver
+        nd.meta['ver'] = ver
+
+        try:
+            oheaders = nd.meta['other_header']
+            for extname, ext in nd.meta['other'].items():
+                try:
+                    oheaders[extname]['EXTVER'] = ver
+                except KeyError:
+                    pass
+                try:
+                    # The object may keep the header on its own structure
+                    ext.meta['header']['EXTVER'] = ver
+                except AttributeError:
+                    pass
+        except KeyError:
+            pass
+
+        return ver
+
+    def _process_pixel_plane(self, pixim, name=None, top_level=False,
+                             reset_ver=True, custom_header=None):
+        if not isinstance(pixim, NDDataObject):
+            # Assume that we get an ImageHDU or something that can be
+            # turned into one
+            if isinstance(pixim, fits.ImageHDU):
+                nd = NDDataObject(pixim.data, meta={'header': pixim.header})
+            elif custom_header is not None:
+                nd = NDDataObject(pixim, meta={'header': custom_header})
+            else:
+                nd = NDDataObject(pixim, meta={'header': {}})
+        else:
+            nd = pixim
+            if custom_header is not None:
+                nd.meta['header'] = custom_header
+
+        header = nd.meta['header']
+        currname = header.get('EXTNAME')
+        ver = header.get('EXTVER', -1)
+
+        # TODO: Review the logic. This one seems bogus
+        if name and (currname is None):
+            header['EXTNAME'] = name if name is not None else DEFAULT_EXTENSION
+
+        if top_level:
+            if 'other' not in nd.meta:
+                nd.meta['other'] = OrderedDict()
+                nd.meta['other_header'] = {}
+
+            if reset_ver or ver == -1:
+                self._reset_ver(nd)
+            else:
+                nd.meta['ver'] = ver
+
+        return nd
+
+    def _add_to_other(self, add_to, name, data, header=None):
+        meta = add_to.meta
+        meta['other'][name] = data
+        if header:
+            header['EXTVER'] = meta.get('ver', -1)
+            meta['other_header'][name] = header
+
+    def _append_array(self, data, name=None, header=None, add_to=None):
+        if add_to is None:
+            # Top level extension
+
+            # Special cases for Gemini
+            if name is None:
+                name = DEFAULT_EXTENSION
+
+            if name in {'DQ', 'VAR'}:
+                raise ValueError("'{}' need to be associated to a '{}' one"
+                                 .format(name, DEFAULT_EXTENSION))
+            else:
+                # FIXME: the logic here is broken since name is
+                # always set to somehing above with DEFAULT_EXTENSION
+                if name is not None:
+                    hname = name
+                elif header is not None:
+                    hname = header.get('EXTNAME', DEFAULT_EXTENSION)
+                else:
+                    hname = DEFAULT_EXTENSION
+
+                hdu = fits.ImageHDU(data, header=header)
+                hdu.header['EXTNAME'] = hname
+                ret = self._append_imagehdu(hdu, name=hname, header=None,
+                                            add_to=None)
+        else:
+            # Attaching to another extension
+            if header is not None and name in {'DQ', 'VAR'}:
+                self._logger.warning(
+                    "The header is ignored for '{}' extensions".format(name))
+            if name is None:
+                raise ValueError("Can't append pixel planes to other "
+                                 "objects without a name")
+            elif name is DEFAULT_EXTENSION:
+                raise ValueError("Can't attach '{}' arrays to other objects"
+                                 .format(DEFAULT_EXTENSION))
+            elif name == 'DQ':
+                add_to.mask = data
+                ret = data
+            elif name == 'VAR':
+                std_un = ADVarianceUncertainty(data)
+                std_un.parent_nddata = add_to
+                add_to.uncertainty = std_un
+                ret = std_un
+            else:
+                self._add_to_other(add_to, name, data, header=header)
+                ret = data
+
+        return ret
+
+    def _append_imagehdu(self, hdu, name, header, add_to, reset_ver=True):
+        if name in {'DQ', 'VAR'} or add_to is not None:
+            return self._append_array(hdu.data, name=name, add_to=add_to)
+        else:
+            nd = self._process_pixel_plane(hdu, name=name, top_level=True,
+                                           reset_ver=reset_ver,
+                                           custom_header=header)
+            return self._append_nddata(nd, name, add_to=None)
+
+    def _append_raw_nddata(self, raw_nddata, name, header, add_to,
+                           reset_ver=True):
+        # We want to make sure that the instance we add is whatever we specify
+        # as `NDDataObject`, instead of the random one that the user may pass
+        top_level = add_to is None
+        if not isinstance(raw_nddata, NDDataObject):
+            raw_nddata = NDDataObject(raw_nddata)
+        processed_nddata = self._process_pixel_plane(raw_nddata,
+                                                     top_level=top_level,
+                                                     custom_header=header,
+                                                     reset_ver=reset_ver)
+        return self._append_nddata(processed_nddata, name=name, add_to=add_to)
+
+    def _append_nddata(self, new_nddata, name, add_to, reset_ver=True):
+        # NOTE: This method is only used by others that have constructed NDData
+        # according to our internal format. We don't accept new headers at this
+        # point, and that's why it's missing from the signature.  'name' is
+        # ignored. It's there just to comply with the _append_XXX signature.
+        if add_to is not None:
+            raise TypeError("You can only append NDData derived instances "
+                            "at the top level")
+
+        hd = new_nddata.meta['header']
+        hname = hd.get('EXTNAME', DEFAULT_EXTENSION)
+        if hname == DEFAULT_EXTENSION:
+            if reset_ver:
+                self._reset_ver(new_nddata)
+            self._nddata.append(new_nddata)
+        else:
+            raise ValueError("Arbitrary image extensions can only be added "
+                             "in association to a '{}'"
+                             .format(DEFAULT_EXTENSION))
+
+        return new_nddata
+
+    def _append_table(self, new_table, name, header, add_to, reset_ver=True):
+        tb = _process_table(new_table, name, header)
+        hname = tb.meta['header'].get('EXTNAME') if name is None else name
+        # if hname is None:
+        #     raise ValueError("Can't attach a table without a name!")
+        if add_to is None:
+            if hname is None:
+                table_num = 1
+                while 'TABLE{}'.format(table_num) in self._tables:
+                    table_num += 1
+                hname = 'TABLE{}'.format(table_num)
+            # Don't use setattr, which is overloaded and may case problems
+            self.__dict__[hname] = tb
+            self._tables[hname] = tb
+            self._exposed.add(hname)
+        else:
+            if hname is None:
+                table_num = 1
+                while getattr(add_to, 'TABLE{}'.format(table_num), None):
+                    table_num += 1
+                hname = 'TABLE{}'.format(table_num)
+            setattr(add_to, hname, tb)
+            self._add_to_other(add_to, hname, tb, tb.meta['header'])
+            add_to.meta['other'][hname] = tb
+        return tb
+
+    def _append_astrodata(self, ad, name, header, add_to, reset_ver=True):
+        if not ad.is_single:
+            raise ValueError("Cannot append AstroData instances that are "
+                             "not single slices")
+        elif add_to is not None:
+            raise ValueError("Cannot append an AstroData slice to "
+                             "another slice")
+
+        new_nddata = deepcopy(ad.nddata)
+        if header is not None:
+            new_nddata.meta['header'] = deepcopy(header)
+
+        return self._append_nddata(new_nddata, name=None, add_to=None,
+                                   reset_ver=True)
+
+    def append(self, ext, name=None, header=None, reset_ver=True, add_to=None):
+        """
+        Adds a new top-level extension. Objects appended to a single
+        slice will actually be made hierarchically dependent of the science
+        object represented by that slice. If appended to the provider as
+        a whole, the new member will be independent (eg. global table, new
+        science object).
+
+        Args
+        -----
+        ext : array, `NDData`, `Table`, other
+            The contents for the new extension. The exact accepted types depend
+            on the class implementing this interface. Implementations specific
+            to certain data formats may accept specialized types (eg. a FITS
+            provider will accept an `ImageHDU` and extract the array out of it)
+
+        name : str, optional
+            A name that may be used to access the new object, as an attribute
+            of the provider. The name is typically ignored for top-level
+            (global) objects, and required for the others. If the name cannot
+            be derived from the metadata associated to `extension`, you will
+            have to provider one.
+
+            It can consist in a combination of numbers and letters, with the
+            restriction that the letters have to be all capital, and the first
+            character cannot be a number ("[A-Z][A-Z0-9]*").
+
+        Returns
+        --------
+        The same object, or a new one, if it was necessary to convert it to
+        a more suitable format for internal use.
+
+        Raises
+        -------
+        TypeError
+            If adding the object in an invalid situation (eg. `name` is `None`
+            when adding to a single slice)
+        ValueError
+            Raised if the extension is of a proper type, but its value is
+            illegal somehow.
+
+        """
+        # NOTE: Most probably, if we want to copy the input argument, we
+        #       should do it here...
+        if isinstance(ext, fits.PrimaryHDU):
+            raise ValueError("Only one Primary HDU allowed. "
+                             "Use set_phu if you really need to set one")
+
+        dispatcher = (
+            (NDData, self._append_raw_nddata),
+            ((Table, fits.TableHDU, fits.BinTableHDU), self._append_table),
+            (fits.ImageHDU, self._append_imagehdu),
+            (AstroData, self._append_astrodata),
+        )
+
+        for bases, method in dispatcher:
+            if isinstance(ext, bases):
+                return method(ext, name=name, header=header, add_to=add_to,
+                              reset_ver=reset_ver)
+        else:
+            # Assume that this is an array for a pixel plane
+            return self._append_array(ext, name=name, header=header,
+                                      add_to=add_to)
+
     @classmethod
     def read(cls, source):
-        """
-        Read from a file, file object, HDUList, etc.
-        """
-        from .fits import read_fits
+        """Read from a file, file object, HDUList, etc."""
         return read_fits(cls, source)
 
     load = read  # for backward compatibility
@@ -1108,7 +1343,6 @@ class AstroData:
                 raise ValueError("A filename needs to be specified")
             filename = self.path
 
-        from .fits import write_fits
         write_fits(self, filename, overwrite=overwrite)
 
     def extver_map(self):
@@ -1337,36 +1571,19 @@ class AstroData:
 
     @astro_data_descriptor
     def instrument(self):
-        """
-        Returns the name of the instrument making the observation
-
-        Returns
-        -------
-        str
-            instrument name
-        """
+        """Returns the name of the instrument making the observation."""
         return self.phu.get(self._keyword_for('instrument'))
 
     @astro_data_descriptor
     def object(self):
-        """
-        Returns the name of the object being observed
-
-        Returns
-        -------
-        str
-            object name
-        """
+        """Returns the name of the object being observed."""
         return self.phu.get(self._keyword_for('object'))
 
     @astro_data_descriptor
     def telescope(self):
-        """
-        Returns the name of the telescope
-
-        Returns
-        -------
-        str
-            name of the telescope
-        """
+        """Returns the name of the telescope."""
         return self.phu.get(self._keyword_for('telescope'))
+
+
+class AstroDataFits(AstroData):
+    """Keep this for now as other classes inherit from it."""

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1244,8 +1244,13 @@ class AstroData:
                 self._logger.warning(
                     "The header is ignored for '{}' extensions".format(name))
             if name is None:
-                raise ValueError("Can't append pixel planes to other "
-                                 "objects without a name")
+                # FIXME: both should raise the same exception
+                if self.is_sliced:
+                    raise TypeError("Can't append objects to a slice "
+                                    "without an extension name")
+                else:
+                    raise ValueError("Can't append pixel planes to other "
+                                     "objects without a name")
             elif name is DEFAULT_EXTENSION:
                 raise ValueError("Can't attach '{}' arrays to other objects"
                                  .format(DEFAULT_EXTENSION))

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1133,8 +1133,6 @@ class AstroData:
         """Read from a file, file object, HDUList, etc."""
         return read_fits(cls, source)
 
-    load = read  # for backward compatibility
-
     def write(self, filename=None, overwrite=False):
         """
         Write the object to disk.

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -78,16 +78,6 @@ class AstroData:
         self._orig_filename = None
         self._path = None
 
-    # def _clone(self):
-    #     # FIXME: this was used by FitsProviderProxy
-    #     obj = self.__class__()
-    #     obj._phu = deepcopy(self._phu)
-    #     for nd in self.nddata:
-    #         obj.append(deepcopy(nd))
-    #     for t in self._tables.values():
-    #         obj.append(deepcopy(t))
-    #     return obj
-
     def __deepcopy__(self, memo):
         """
         Returns a new instance of this class.
@@ -117,6 +107,12 @@ class AstroData:
         # Top-level tables
         for key in set(self.__dict__) - set(obj.__dict__):
             obj.__dict__[key] = obj.__dict__['_tables'][key]
+
+        # FIXME: this was used by FitsProviderProxy, not sure which way is best
+        # for nd in self.nddata:
+        #     obj.append(deepcopy(nd))
+        # for t in self._tables.values():
+        #     obj.append(deepcopy(t))
 
         return obj
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -77,7 +77,6 @@ class AstroData:
         self._logger = logging.getLogger(__name__)
         self._orig_filename = None
         self._path = None
-        self._resetting = False
 
     # def _clone(self):
     #     # FIXME: this was used by FitsProviderProxy
@@ -105,8 +104,7 @@ class AstroData:
 
         obj = self.__class__()
 
-        for attr in ('_phu', '_path', '_orig_filename', '_tables',
-                     '_exposed', '_resetting'):
+        for attr in ('_phu', '_path', '_orig_filename', '_tables', '_exposed'):
             obj.__dict__[attr] = deepcopy(self.__dict__[attr])
 
         if self.is_single:
@@ -577,15 +575,9 @@ class AstroData:
             # the NDData objects. First we check if the attribute belongs to
             # this object's dictionary.  Otherwise, see if we can pass it down.
             #
-            # self._resetting shortcircuits the method when populating the
-            # object. In that situation, we don't want to interfere. Of course,
-            # we need to check first if self._resetting is there, because
-            # otherwise we enter a loop..  CJS 20200131: if the attribute is
-            # "exposed" then we should set it via the append method I think
-            # (it's a Table or something)
+            # CJS 20200131: if the attribute is "exposed" then we should set
+            # it via the append method I think (it's a Table or something)
             if (self.is_settable(attribute) and
-                    '_resetting' in self.__dict__ and
-                    not self._resetting and
                     (not _my_attribute(attribute) or
                      attribute in self._exposed)):
                 if self.is_sliced and not self.is_single:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -164,6 +164,7 @@ class AstroData:
 
         """
         # This prevents infinite recursion
+        # FIXME: probably not more needed since we inspect the class ?
         if self._processing_tags:
             return set()
         self._processing_tags = True
@@ -171,17 +172,11 @@ class AstroData:
             results = []
             # Calling inspect.getmembers on `self` would trigger all the
             # properties (tags, phu, hdr, etc.), and that's undesirable. To
-            # prevent that, we'll inspect the *class*. But that returns us
-            # unbound methods. We use `method.__get__(self)` to get a bound
-            # version.
-            #
-            # It's a bit of a roundabout way to get to what we want, but it's
-            # better than the option...
+            # prevent that, we'll inspect the *class*.
             filt = lambda x: hasattr(x, 'tag_method')
             for mname, method in inspect.getmembers(self.__class__, filt):
-                ts = method.__get__(self)()
-                plus, minus, blocked_by, blocks, if_present = ts
-                if plus or minus or blocks:
+                ts = method(self)
+                if ts.add or ts.remove or ts.blocks:
                     results.append(ts)
 
             # Sort by the length of substractions... those that substract

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -301,7 +301,7 @@ class AstroData:
 
     def _process_tags(self):
         """
-        Determines the tag set for the current instance
+        Determines the tag set for the current instance.
 
         Returns
         --------
@@ -313,24 +313,33 @@ class AstroData:
         self._processing_tags = True
         try:
             results = []
-            # Calling inspect.getmembers on `self` would trigger all the properties (tags,
-            # phu, hdr, etc.), and that's undesirable. To prevent that, we'll inspect the
-            # *class*. But that returns us unbound methods. We use `method.__get__(self)` to
-            # get a bound version.
+            # Calling inspect.getmembers on `self` would trigger all the
+            # properties (tags, phu, hdr, etc.), and that's undesirable. To
+            # prevent that, we'll inspect the *class*. But that returns us
+            # unbound methods. We use `method.__get__(self)` to get a bound
+            # version.
             #
-            # It's a bit of a roundabout way to get to what we want, but it's better than
-            # the option...
-            for mname, method in inspect.getmembers(self.__class__, lambda x: hasattr(x, 'tag_method')):
+            # It's a bit of a roundabout way to get to what we want, but it's
+            # better than the option...
+            filt = lambda x: hasattr(x, 'tag_method')
+            for mname, method in inspect.getmembers(self.__class__, filt):
                 ts = method.__get__(self)()
                 plus, minus, blocked_by, blocks, if_present = ts
                 if plus or minus or blocks:
                     results.append(ts)
 
-            # Sort by the length of substractions... those that substract from others go first
-            results = sorted(results, key=lambda x: len(x.remove) + len(x.blocks), reverse=True)
-            # Sort by length of blocked_by... those that are never disabled go first
+            # Sort by the length of substractions... those that substract
+            # from others go first
+            results = sorted(results,
+                             key=lambda x: len(x.remove) + len(x.blocks),
+                             reverse=True)
+
+            # Sort by length of blocked_by... those that are never disabled
+            # go first
             results = sorted(results, key=lambda x: len(x.blocked_by))
-            # Sort by length of if_present... those that need other tags to be present go last
+
+            # Sort by length of if_present... those that need other tags to
+            # be present go last
             results = sorted(results, key=lambda x: len(x.if_present))
 
             tags = set()
@@ -338,8 +347,8 @@ class AstroData:
             blocked = set()
             for plus, minus, blocked_by, blocks, is_present in results:
                 if is_present:
-                    # If this TagSet requires other tags to be present, make sure that all of
-                    # them are. Otherwise, skip...
+                    # If this TagSet requires other tags to be present, make
+                    # sure that all of them are. Otherwise, skip...
                     if len(tags & is_present) != len(is_present):
                         continue
                 allowed = (len(tags & blocked_by) + len(plus & blocked)) == 0
@@ -354,7 +363,7 @@ class AstroData:
         return tags
 
     @staticmethod
-    def _matches_data(dataprov):
+    def _matches_data(source):
         # This one is trivial. As long as we get a FITS file...
         return True
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -80,16 +80,15 @@ class AstroData:
         self._processing_tags = False
         self._resetting = False
 
-    def _clone(self):
-        # FIXME: this was used by FitsProviderProxy
-        obj = self.__class__()
-        obj._phu = deepcopy(self._phu)
-        for nd in self.nddata:
-            obj.append(deepcopy(nd))
-        for t in self._tables.values():
-            obj.append(deepcopy(t))
-
-        return obj
+    # def _clone(self):
+    #     # FIXME: this was used by FitsProviderProxy
+    #     obj = self.__class__()
+    #     obj._phu = deepcopy(self._phu)
+    #     for nd in self.nddata:
+    #         obj.append(deepcopy(nd))
+    #     for t in self._tables.values():
+    #         obj.append(deepcopy(t))
+    #     return obj
 
     def __deepcopy__(self, memo):
         """

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -276,7 +276,8 @@ class AstroData:
     @deprecated("Access to headers through this property is deprecated and "
                 "will be removed in the future. Use '.hdr' instead.")
     def header(self):
-        return [self._phu] + [ndd.meta['header'] for ndd in self.nddata]
+        nddata = [self.nddata] if self.is_single else self.nddata
+        return [self._phu] + [ndd.meta['header'] for ndd in nddata]
 
     @property
     def tags(self):
@@ -554,7 +555,8 @@ class AstroData:
             return self.__dict__[attribute]
 
         # Check if it's an aliased object
-        for nd in self.nddata:
+        nddata = [self.nddata] if self.is_single else self.nddata
+        for nd in nddata:
             if nd.meta.get('name') == attribute:
                 return nd
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -25,10 +25,6 @@ from .utils import (assign_only_single_slice, astro_data_descriptor,
 NO_DEFAULT = object()
 
 
-class AstroDataError(Exception):
-    pass
-
-
 _arit_doc = """
     Performs {name} by evaluating ``self`` {op} ``operand``.
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1595,6 +1595,27 @@ class AstroData:
         # Cope with prefix or suffix as None
         self.filename = (prefix or '') + root + (suffix or '') + filetype
 
+    def _crop_nd(self, nd, x1, y1, x2, y2):
+        nd.data = nd.data[y1:y2+1, x1:x2+1]
+        if nd.uncertainty is not None:
+            nd.uncertainty = nd.uncertainty[y1:y2+1, x1:x2+1]
+        if nd.mask is not None:
+            nd.mask = nd.mask[y1:y2+1, x1:x2+1]
+
+    def crop(self, x1, y1, x2, y2):
+        # TODO: Consider cropping of objects in the meta section
+        for nd in self.nddata:
+            orig_shape = nd.data.shape
+            self._crop_nd(nd, x1, y1, x2, y2)
+            for o in nd.meta['other'].values():
+                try:
+                    if o.shape == orig_shape:
+                        self._crop_nd(o, x1, y1, x2, y2)
+                except AttributeError:
+                    # No 'shape' attribute in the object. It's probably
+                    # not array-like
+                    pass
+
     @astro_data_descriptor
     def instrument(self):
         """Returns the name of the instrument making the observation."""

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -19,8 +19,8 @@ from .fits import (DEFAULT_EXTENSION, FitsHeaderCollection, _process_table,
                    read_fits, write_fits)
 from .nddata import ADVarianceUncertainty
 from .nddata import NDAstroData as NDDataObject
-from .utils import (astro_data_descriptor, deprecated, normalize_indices,
-                    returns_list)
+from .utils import (assign_only_single_slice, astro_data_descriptor,
+                    deprecated, normalize_indices, returns_list)
 
 NO_DEFAULT = object()
 
@@ -269,7 +269,7 @@ class AstroData:
     @deprecated("Access to headers through this property is deprecated and "
                 "will be removed in the future. Use '.hdr' instead.")
     def header(self):
-        return [self._phu] + [ndd.meta['header'] for ndd in self._nddata]
+        return [self.phu] + [ndd.meta['header'] for ndd in self._nddata]
 
     @property
     def tags(self):
@@ -362,11 +362,8 @@ class AstroData:
         return [nd.data for nd in self._nddata]
 
     @data.setter
+    @assign_only_single_slice
     def data(self, value):
-        if not self.is_single:
-            raise ValueError("Trying to assign to an AstroData object that "
-                             "is not a single slice")
-
         # Setting the ._data in the NDData is a bit kludgy, but we're all
         # grown adults and know what we're doing, isn't it?
         if hasattr(value, 'shape'):
@@ -393,10 +390,8 @@ class AstroData:
         return [nd.uncertainty for nd in self._nddata]
 
     @uncertainty.setter
+    @assign_only_single_slice
     def uncertainty(self, value):
-        if not self.is_single:
-            raise ValueError("Trying to assign to an AstroData object that "
-                             "is not a single slice")
         self.nddata.uncertainty = value
 
     @property
@@ -411,10 +406,8 @@ class AstroData:
         return [nd.mask for nd in self._nddata]
 
     @mask.setter
+    @assign_only_single_slice
     def mask(self, value):
-        if not self.is_single:
-            raise ValueError("Trying to assign to an AstroData object that "
-                             "is not a single slice")
         self.nddata.mask = value
 
     @property
@@ -436,10 +429,8 @@ class AstroData:
         return [nd.variance for nd in self._nddata]
 
     @variance.setter
+    @assign_only_single_slice
     def variance(self, value):
-        if not self.is_single:
-            raise ValueError("Trying to assign to an AstroData object that "
-                             "is not a single slice")
         if value is None:
             self.nddata.uncertainty = None
         else:
@@ -455,10 +446,8 @@ class AstroData:
                              "that is not a single slice")
 
     @wcs.setter
+    @assign_only_single_slice
     def wcs(self, value):
-        if not self.is_single:
-            raise ValueError("Trying to assign to an AstroData object "
-                             "that is not a single slice")
         self.nddata.wcs = value
 
     def __iter__(self):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1,4 +1,6 @@
 import inspect
+import os
+import re
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
 from copy import deepcopy
@@ -441,6 +443,16 @@ class AstroData:
     # Simply a value that nobody is going to try to set an NDData attribute to
     _IGNORE = -23
 
+    # Derived classes may provide their own __keyword_dict. Being a private
+    # variable, each class will preserve its own, and there's no risk of
+    # overriding the whole thing
+    __keyword_dict = {
+        'instrument': 'INSTRUME',
+        'object': 'OBJECT',
+        'telescope': 'TELESCOP',
+        'ut_date': 'DATE-OBS'
+    }
+
     def __init__(self, provider):
         if not isinstance(provider, DataProvider):
             raise ValueError("AstroData is initialized with a DataProvider object. You may want to use ad.open('...') instead")
@@ -465,6 +477,36 @@ class AstroData:
         dp = deepcopy(self._dataprov, memo)
         ad = self.__class__(dp)
         return ad
+
+    def _keyword_for(self, name):
+        """
+        Returns the FITS keyword name associated to ``name``.
+
+        Parameters
+        ----------
+        name : str
+            The common "key" name for which we want to know the associated
+            FITS keyword
+
+        Returns
+        -------
+        str
+            The desired keyword name
+
+        Raises
+        ------
+        AttributeError
+            If there is no keyword for the specified ``name``
+        """
+
+        for cls in self.__class__.mro():
+            mangled_dict_name = '_{}__keyword_dict'.format(cls.__name__)
+            try:
+                return getattr(self, mangled_dict_name)[name]
+            except (AttributeError, KeyError):
+                pass
+        else:
+            raise AttributeError("No match for '{}'".format(name))
 
     def __process_tags(self):
         """
@@ -1018,3 +1060,100 @@ class AstroData:
 
         if hasattr(data, 'wcs'):
             self.wcs = data.wcs
+
+    def update_filename(self, prefix=None, suffix=None, strip=False):
+        """
+        This method updates the "filename" attribute of the AstroData object.
+        A prefix and/or suffix can be specified. If strip=True, these will
+        replace the existing prefix/suffix; if strip=False, they will simply
+        be prepended/appended.
+
+        The current filename is broken down into its existing prefix, root,
+        and suffix using the ORIGNAME phu keyword, if it exists and is
+        contained within the current filename. Otherwise, the filename is
+        split at the last underscore and the part before is assigned as the
+        root and the underscore and part after the suffix. No prefix is
+        assigned.
+
+        Note that, if strip=True, a prefix or suffix will only be stripped
+        if '' is specified.
+
+        Parameters
+        ----------
+        prefix: str/None
+            new prefix (None => leave alone)
+        suffix: str/None
+            new suffix (None => leave alone)
+        strip: bool
+            Strip existing prefixes and suffixes if new ones are given?
+        """
+        if self.filename is None:
+            if 'ORIGNAME' in self.phu:
+                self.filename = self.phu['ORIGNAME']
+            else:
+                raise ValueError("A filename needs to be set before it "
+                                 "can be updated")
+
+        # Set the ORIGNAME keyword if it's not there
+        if 'ORIGNAME' not in self.phu:
+            self.phu.set('ORIGNAME', self.orig_filename,
+                         'Original filename prior to processing')
+
+        if strip:
+            root, filetype = os.path.splitext(self.phu['ORIGNAME'])
+            filename, filetype = os.path.splitext(self.filename)
+            m = re.match('(.*){}(.*)'.format(re.escape(root)), filename)
+            # Do not strip a prefix/suffix unless a new one is provided
+            if m:
+                if prefix is None:
+                    prefix = m.groups()[0]
+                existing_suffix = m.groups()[1]
+            else:
+                try:
+                    root, existing_suffix = filename.rsplit("_", 1)
+                    existing_suffix = "_" + existing_suffix
+                except ValueError:
+                    root, existing_suffix = filename, ''
+            if suffix is None:
+                suffix = existing_suffix
+        else:
+            root, filetype = os.path.splitext(self.filename)
+
+        # Cope with prefix or suffix as None
+        self.filename = (prefix or '') + root + (suffix or '') + filetype
+
+    @astro_data_descriptor
+    def instrument(self):
+        """
+        Returns the name of the instrument making the observation
+
+        Returns
+        -------
+        str
+            instrument name
+        """
+        return self.phu.get(self._keyword_for('instrument'))
+
+    @astro_data_descriptor
+    def object(self):
+        """
+        Returns the name of the object being observed
+
+        Returns
+        -------
+        str
+            object name
+        """
+        return self.phu.get(self._keyword_for('object'))
+
+    @astro_data_descriptor
+    def telescope(self):
+        """
+        Returns the name of the telescope
+
+        Returns
+        -------
+        str
+            name of the telescope
+        """
+        return self.phu.get(self._keyword_for('telescope'))

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -653,8 +653,11 @@ class AstroData:
         if self._indices:
             indices = [self._indices[i] for i in indices]
 
-        return self.__class__(self._nddata, tables=self._tables, phu=self.phu,
-                              indices=indices)
+        obj = self.__class__(self._nddata, tables=self._tables, phu=self.phu,
+                             indices=indices)
+        obj._path = self.path
+        obj._orig_filename = self.orig_filename
+        return obj
 
     def __delitem__(self, idx):
         """

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -291,6 +291,7 @@ class AstroData:
 
     @property
     def indices(self):
+        """Returns the extensions indices for sliced objects."""
         return self._indices if self._indices else list(range(len(self)))
 
     @property
@@ -455,6 +456,7 @@ class AstroData:
 
     @property
     def wcs(self):
+        """Returns the list of WCS objects for each extension."""
         if self.is_single:
             return self.nddata.wcs
         else:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -19,7 +19,8 @@ from .fits import (DEFAULT_EXTENSION, FitsHeaderCollection, _process_table,
                    read_fits, write_fits)
 from .nddata import ADVarianceUncertainty
 from .nddata import NDAstroData as NDDataObject
-from .utils import astro_data_descriptor, deprecated, normalize_indices
+from .utils import (astro_data_descriptor, deprecated, normalize_indices,
+                    returns_list)
 
 NO_DEFAULT = object()
 
@@ -347,22 +348,18 @@ class AstroData:
         return set(self._tables.keys())
 
     @property
+    @returns_list
     def shape(self):
-        if self.is_single:
-            return self.nddata.shape
-        else:
-            return [nd.shape for nd in self.nddata]
+        return [nd.shape for nd in self._nddata]
 
     @property
+    @returns_list
     def data(self):
         """
         A list of the arrays (or single array, if this is a single slice)
         corresponding to the science data attached to each extension.
         """
-        if self.is_single:
-            return self.nddata.data
-        else:
-            return [nd.data for nd in self.nddata]
+        return [nd.data for nd in self._nddata]
 
     @data.setter
     def data(self, value):
@@ -379,6 +376,7 @@ class AstroData:
                                  "with no shape")
 
     @property
+    @returns_list
     def uncertainty(self):
         """
         A list of the uncertainty objects (or a single object, if this is
@@ -392,10 +390,7 @@ class AstroData:
         variance : The actual array supporting the uncertainty object
 
         """
-        if self.is_single:
-            return self.nddata.uncertainty
-        else:
-            return [nd.uncertainty for nd in self.nddata]
+        return [nd.uncertainty for nd in self._nddata]
 
     @uncertainty.setter
     def uncertainty(self, value):
@@ -405,6 +400,7 @@ class AstroData:
         self.nddata.uncertainty = value
 
     @property
+    @returns_list
     def mask(self):
         """
         A list of the mask arrays (or a single array, if this is a single
@@ -412,10 +408,7 @@ class AstroData:
 
         For objects that miss a mask, `None` will be provided instead.
         """
-        if self.is_single:
-            return self.nddata.mask
-        else:
-            return [nd.mask for nd in self.nddata]
+        return [nd.mask for nd in self._nddata]
 
     @mask.setter
     def mask(self, value):
@@ -425,6 +418,7 @@ class AstroData:
         self.nddata.mask = value
 
     @property
+    @returns_list
     def variance(self):
         """
         A list of the variance arrays (or a single array, if this is a single
@@ -439,10 +433,7 @@ class AstroData:
         propagate uncertainty when operating with the data.
 
         """
-        if self.is_single:
-            return self.nddata.variance
-        else:
-            return [nd.variance for nd in self.nddata]
+        return [nd.variance for nd in self._nddata]
 
     @variance.setter
     def variance(self, value):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -792,8 +792,13 @@ class AstroData:
         else:
             # TODO: So far we're only deleting tables by name.
             #       Figure out what to do with aliases
-            if not attribute.isupper() and attribute in self._tables:
-                del self._tables[attribute]
+            if attribute.isupper():
+                if attribute in self._tables:
+                    del self._tables[attribute]
+                else:
+                    raise AttributeError(
+                        "'{}' is not a global table for this instance"
+                        .format(attribute))
             else:
                 super().__delattr__(attribute)
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -2,10 +2,10 @@ import inspect
 import logging
 import os
 import re
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict
 from contextlib import suppress
 from copy import deepcopy
-from functools import partial, wraps
+from functools import partial
 
 import numpy as np
 
@@ -16,159 +16,9 @@ from astropy.table import Table
 from .fits import DEFAULT_EXTENSION, _process_table, read_fits, write_fits
 from .nddata import ADVarianceUncertainty
 from .nddata import NDAstroData as NDDataObject
-from .utils import deprecated, normalize_indices
+from .utils import deprecated, normalize_indices, astro_data_descriptor
 
 NO_DEFAULT = object()
-
-
-class TagSet(namedtuple('TagSet', 'add remove blocked_by blocks if_present')):
-    """
-    TagSet(add=None, remove=None, blocked_by=None, blocks=None, if_present=None)
-
-    Named tuple that is used by tag methods to return which actions should be
-    performed on a tag set. All the attributes are optional, and any
-    combination of them can be used, allowing to create complex tag structures.
-    Read the documentation on the tag-generating algorithm if you want to
-    better understand the interactions.
-
-    The simplest TagSet, though, tends to just add tags to the global set.
-
-    It can be initialized by position, like any other tuple (the order of the
-    arguments is the one in which the attributes are listed below). It can
-    also be initialized by name.
-
-    Attributes
-    ----------
-    add : set of str, or None
-        Tags to be added to the global set
-    remove : set of str, or None
-        Tags to be removed from the global set
-    blocked_by : set of str, or None
-        Tags that will prevent this TagSet from being applied
-    blocks : set of str, or None
-        Other TagSets containing these won't be applied
-    if_present : set of str, or None
-        This TagSet will be applied only *all* of these tags are present
-
-    Examples
-    ---------
-    >>> TagSet()
-    TagSet(add=set(), remove=set(), blocked_by=set(), blocks=set(), if_present=set())
-    >>> TagSet({'BIAS', 'CAL'})
-    TagSet(add={'BIAS', 'CAL'}, remove=set(), blocked_by=set(), blocks=set(), if_present=set())
-    >>> TagSet(remove={'BIAS', 'CAL'})
-    TagSet(add=set(), remove={'BIAS', 'CAL'}, blocked_by=set(), blocks=set(), if_present=set())
-
-    """
-    def __new__(cls, add=None, remove=None, blocked_by=None, blocks=None, if_present=None):
-        return super().__new__(cls, add or set(),
-                               remove or set(),
-                               blocked_by or set(),
-                               blocks or set(),
-                               if_present or set())
-
-
-def astro_data_descriptor(fn):
-    """
-    Decorator that will mark a class method as an AstroData descriptor.
-    Useful to produce list of descriptors, for example.
-
-    If used in combination with other decorators, this one *must* be the
-    one on the top (ie. the last one applying). It doesn't modify the
-    method in any other way.
-
-    Args
-    -----
-    fn : method
-        The method to be decorated
-
-    Returns
-    --------
-    The tagged method (not a wrapper)
-    """
-    fn.descriptor_method = True
-    return fn
-
-
-def returns_list(fn):
-    """
-    Decorator to ensure that descriptors that should return a list (of one
-    value per extension) only returns single values when operating on
-    single slices; and vice versa.
-
-    This is a common case, and you can use the decorator to simplify the
-    logic of your descriptors.
-
-    Args
-    -----
-    fn : method
-        The method to be decorated
-
-    Returns
-    --------
-    A function
-    """
-    @wraps(fn)
-    def wrapper(self, *args, **kwargs):
-        ret = fn(self, *args, **kwargs)
-        if self.is_single:
-            if isinstance(ret, list):
-                # TODO: log a warning if the list is >1 element
-                if len(ret) > 1:
-                    pass
-                return ret[0]
-            else:
-                return ret
-        else:
-            if isinstance(ret, list):
-                if len(ret) == len(self):
-                    return ret
-                else:
-                    raise IndexError(
-                        "Incompatible numbers of extensions and elements in {}"
-                        .format(fn.__name__))
-            else:
-                return [ret] * len(self)
-    return wrapper
-
-
-def astro_data_tag(fn):
-    """
-    Decorator that marks methods of an `AstroData` derived class as part of the
-    tag-producing system.
-
-    It wraps the method around a function that will ensure a consistent return
-    value: the wrapped method can return any sequence of sequences of strings,
-    and they will be converted to a TagSet. If the wrapped method
-    returns None, it will be turned into an empty TagSet.
-
-    Args
-    -----
-    fn : method
-        The method to be decorated
-
-    Returns
-    --------
-    A wrapper function
-    """
-    @wraps(fn)
-    def wrapper(self):
-        try:
-            ret = fn(self)
-            if ret is not None:
-                if not isinstance(ret, TagSet):
-                    raise TypeError("Tag function {} didn't return a TagSet"
-                                    .format(fn.__name__))
-
-                return TagSet(*tuple(set(s) for s in ret))
-        except KeyError:
-            pass
-
-        # Return empty TagSet for the "doesn't apply" case
-        return TagSet()
-
-    wrapper.tag_method = True
-    return wrapper
 
 
 class AstroDataError(Exception):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -198,16 +198,19 @@ class AstroData:
         'ut_date': 'DATE-OBS'
     }
 
-    def __init__(self, nddata=None, other=None, phu=None, indices=None):
+    def __init__(self, nddata=None, tables=None, phu=None, indices=None):
         if nddata is None:
             nddata = []
         if not isinstance(nddata, (list, tuple)):
             nddata = list(nddata)
 
         self._nddata = nddata
-        self._other = other
         self._phu = phu or fits.Header()
         self._indices = indices
+
+        if tables is not None and not isinstance(tables, dict):
+            raise ValueError('tables must be a dict')
+        self._tables = tables or {}
 
         self._exposed = set()
         self._fixed_settable = {'data', 'uncertainty', 'mask', 'variance',
@@ -217,7 +220,6 @@ class AstroData:
         self._path = None
         self._processing_tags = False
         self._resetting = False
-        self._tables = {}
 
     def _clone(self):
         # FIXME: this was used by FitsProviderProxy
@@ -649,9 +651,7 @@ class AstroData:
         if self._indices:
             indices = [self._indices[i] for i in indices]
 
-        return self.__class__(self.nddata,
-                              # other=self.other,
-                              phu=self.phu,
+        return self.__class__(self._nddata, tables=self._tables, phu=self.phu,
                               indices=indices)
 
     def __delitem__(self, idx):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1683,7 +1683,8 @@ class AstroData:
 
     def crop(self, x1, y1, x2, y2):
         # TODO: Consider cropping of objects in the meta section
-        for nd in self.nddata:
+        nddata = [self.nddata] if self.is_single else self.nddata
+        for nd in nddata:
             orig_shape = nd.data.shape
             self._crop_nd(nd, x1, y1, x2, y2)
             for o in nd.meta['other'].values():

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1129,9 +1129,11 @@ class AstroData:
                                       add_to=add_to)
 
     @classmethod
-    def read(cls, source):
+    def read(cls, source, extname_parser=None):
         """Read from a file, file object, HDUList, etc."""
-        return read_fits(cls, source)
+        return read_fits(cls, source, extname_parser=extname_parser)
+
+    load = read  # for backward compatibility
 
     def write(self, filename=None, overwrite=False):
         """

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -396,6 +396,10 @@ class AstroData:
     def orig_filename(self):
         return self._orig_filename
 
+    @orig_filename.setter
+    def orig_filename(self, value):
+        self._orig_filename = value
+
     @property
     def phu(self):
         return self._phu

--- a/astrodata/doc/ad_ProgManual/adclass.rst
+++ b/astrodata/doc/ad_ProgManual/adclass.rst
@@ -6,19 +6,17 @@
 AstroData and Derivatives
 *************************
 
-The ``astrodata.core.AstroData`` class (or simply ``astrodata.AstroData``)
-is the main interface to the package. When
-opening files or creating new objects, a derivative of this class is
-returned, as the ``AstroData``
-class is not intended to be used directly. It provides the logic to calculate
-the :ref:`tag set <ad_tags>` for an image, which is common to all data products. Aside from
-that, it lacks any kind of specialized knowledge about the different
-instruments that produce the FITS files. More importantly, it defines two
-methods (``info`` and ``load``) as abstract, meaning that the class cannot be
-instantiated directly: a derivative must implement those methods in order to be
-useful. Such derivatives can also implement descriptors, which provide
-processed metadata in a way that abstracts the user from the raw information
-(e.g., the keywords in FITS headers).
+The ``astrodata.AstroData`` class is the main interface to the package. When
+opening files or creating new objects, a derivative of this class is returned,
+as the ``AstroData`` class is not intended to be used directly. It provides the
+logic to calculate the :ref:`tag set <ad_tags>` for an image, which is common
+to all data products. Aside from that, it lacks any kind of specialized
+knowledge about the different instruments that produce the FITS files. More
+importantly, it defines two methods (``info`` and ``load``) as abstract,
+meaning that the class cannot be instantiated directly: a derivative must
+implement those methods in order to be useful. Such derivatives can also
+implement descriptors, which provide processed metadata in a way that abstracts
+the user from the raw information (e.g., the keywords in FITS headers).
 
 ``AstroData`` does define a common interface, though. Much of it consists on
 implementing semantic behavior (access to components through indices, like a
@@ -44,9 +42,8 @@ standard Python methods:
 * Implements ``__iadd__``, ``__isub__``, ``__imul__``, ``__itruediv__``, and
   their not-in-place versions, based on them.
 
-All of these provide default implementations that rely heavily on the
-``DataProvider`` capabilities. There are a few other methods. For a detailed
-discussion, please refer to the :ref:`api_refguide`.
+There are a few other methods. For a detailed discussion, please refer to the
+:ref:`api_refguide`.
 
 .. _tags_prop_entry:
 
@@ -61,7 +58,7 @@ fast to compare sets, e.g., testing for membership; or calculating intersection,
 etc., to figure out if a certain dataset belongs to an arbitrary category.
 
 The implementation for the tags property is just a call to
-``AstroData.__process_tags()``. This function implements the actual logic behind
+``AstroData._process_tags()``. This function implements the actual logic behind
 calculating the tag set (described :ref:`below <ad_tags>`). A derivative class
 could redefine the algorithm, or build upon it.
 

--- a/astrodata/doc/ad_ProgManual/appendices/api_refguide.rst
+++ b/astrodata/doc/ad_ProgManual/appendices/api_refguide.rst
@@ -39,17 +39,10 @@ covering the usage of Gemini-style FITS files.
 
       Alias for ``__itruediv__``
 
-``DataProvider``
-----------------
-
-.. autoclass:: astrodata.core.DataProvider
-   :members:
-   :special-members:
-
 ``TagSet``
 ==========
 
-.. autoclass:: astrodata.core.TagSet
+.. autoclass:: astrodata.TagSet
 
 ``NDAstroData``
 ===============
@@ -62,8 +55,8 @@ covering the usage of Gemini-style FITS files.
 Decorators and other helper functions
 =====================================
 
-.. autofunction:: astrodata.core.astro_data_descriptor
+.. autofunction:: astrodata.astro_data_descriptor
 
-.. autofunction:: astrodata.core.astro_data_tag
+.. autofunction:: astrodata.astro_data_tag
 
-.. autofunction:: astrodata.core.returns_list
+.. autofunction:: astrodata.returns_list

--- a/astrodata/doc/ad_ProgManual/conf.py
+++ b/astrodata/doc/ad_ProgManual/conf.py
@@ -98,8 +98,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#
-# default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #
@@ -358,7 +357,14 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'gemini_instruments': ('https://dragons-recipe-system-programmers-manual.readthedocs.io/en/latest/', None),
+    'geminidr': ('https://dragons-recipe-system-programmers-manual.readthedocs.io/en/latest/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'python': ('https://docs.python.org/3', None),
+}
+
 
 
 # -- Finishing with a setup that will run always -----------------------------

--- a/astrodata/doc/ad_ProgManual/containers.rst
+++ b/astrodata/doc/ad_ProgManual/containers.rst
@@ -13,16 +13,12 @@ in read-only, memory-mapping mode, and exploiting the windowing capability of
 PyFITS\ [#pyfits]_ (using ``section``) to reduce our memory requirements, which
 becomes important when reducing data (e.g., stacking).
 
-We document our container for completeness and for reference, but note that its
-use is intimately linked to ``FitsProvider``. If you're implementing an alternative
-data provider, you do not need to follow our design.
-
 We'll describe here how we depart from NDData, and how do we integrate the data
 containers with the rest of the package. Please refer to NDData for the full
 interface.
 
-Our main data container is ``astrodata.nddata.NDAstroData``. Fundamentally, it
-is a derivative of ``astropy.nddata.NDData``, plus a number of mixins to add
+Our main data container is `astrodata.nddata.NDAstroData`. Fundamentally, it
+is a derivative of `astropy.nddata.NDData`, plus a number of mixins to add
 functionality::
 
     class NDAstroData(NDArithmeticMixin, NDSlicingMixin, NDData):

--- a/astrodata/doc/ad_ProgManual/design.rst
+++ b/astrodata/doc/ad_ProgManual/design.rst
@@ -40,7 +40,7 @@ of the MEF format. One example is the creation and propagation of information
 describing the quality and uncertainty of the scientific data: while
 this was a feature of
 Gemini IRAF\ [#iraf]_, the coding required to implement it was cumbersome
-and AstroData uses the ``astropy.nddata.NDData`` class,
+and AstroData uses the `astropy.nddata.NDData` class,
 as discussed in :ref:`containers`. This makes the relationship between these
 data much clearer, and AstroData creates a syntax that makes readily apparent the
 roles of other data and metadata that may be created during the reduction

--- a/astrodata/doc/ad_UserManual/conf.py
+++ b/astrodata/doc/ad_UserManual/conf.py
@@ -89,7 +89,7 @@ today = 'April 2020'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True

--- a/astrodata/doc/ad_UserManual/conf.py
+++ b/astrodata/doc/ad_UserManual/conf.py
@@ -276,10 +276,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'astropy': ('http://docs.astropy.org/en/stable/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
     'gemini_instruments': ('https://dragons-recipe-system-programmers-manual.readthedocs.io/en/latest/', None),
     'geminidr': ('https://dragons-recipe-system-programmers-manual.readthedocs.io/en/latest/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'python': ('https://docs.python.org/3', None),
 }
 

--- a/astrodata/doc/ad_UserManual/data.rst
+++ b/astrodata/doc/ad_UserManual/data.rst
@@ -1,6 +1,6 @@
 .. data.rst
 
-.. _data:
+.. _pixel-data:
 
 **********
 Pixel Data
@@ -698,7 +698,7 @@ A new feature presented in this example is the ability to work on the
 ``NDAstroData`` object directly.  This is particularly useful when cropping
 the science pixel array as one will want the variance and the mask arrays
 cropped exactly the same way.  Taking a section of the ``NDAstroData``
-object (ad[0].nddata[y1:y2, x1:x2]), instead of just the `.data` array,
+object (ad[0].nddata[y1:y2, x1:x2]), instead of just the ``.data`` array,
 does all that for us.
 
 To reassign the cropped ``NDAstroData`` to the extension one uses the
@@ -901,4 +901,3 @@ what ``imexam`` has to offer.
     >>> plot.contour_pars['ncolumns'][0] = width
     >>> plot.contour_pars['nlines'][0] = width
     >>> plot.contour(center[1], center[0], ad_image[0].data)
-

--- a/astrodata/doc/ad_UserManual/headers.rst
+++ b/astrodata/doc/ad_UserManual/headers.rst
@@ -215,8 +215,8 @@ World Co-ordinate System attribute
 ==================================
 
 The ``wcs`` of an extension's ``nddata`` attribute (eg. ``ad[0].nddata.wcs``;
-see :ref:`data`) may contain an instance of ``astropy.wcs.WCS`` (a standard
-FITS WCS object) or ``gwcs.WCS`` (a `"Generalized WCS" or gWCS
+see :ref:`pixel-data`) may contain an instance of ``astropy.wcs.WCS`` (a
+standard FITS WCS object) or ``gwcs.WCS`` (a `"Generalized WCS" or gWCS
 <https://gwcs.readthedocs.io>`_ object). These both define a transformation
 between array indices and some other co-ordinate system such as "World"
 co-ordinates (see `APE 14

--- a/astrodata/doc/ad_UserManual/intro.rst
+++ b/astrodata/doc/ad_UserManual/intro.rst
@@ -18,8 +18,8 @@ how multi-extension (MEF) FITS files are represented. :ref:`Chapter 4 <tags>`
 provides information regarding the |TagSet| class, its usage and a few advanced
 topics. In :ref:`Chapter 5 <headers>` you will find information about the FITS
 headers and how to access/modify the metadata. The last two chapters,
-:ref:`Chapter 6 <data>` and :ref:`Chapter 7 <tables>` cover more details about
-how to read, manipulate and write pixel data and tables, respectively.
+:ref:`Chapter 6 <pixel-data>` and :ref:`Chapter 7 <tables>` cover more details
+about how to read, manipulate and write pixel data and tables, respectively.
 
 
 If you are looking for a quick reference, please, have a look on the

--- a/astrodata/factory.py
+++ b/astrodata/factory.py
@@ -4,13 +4,15 @@ from copy import deepcopy
 
 from astropy.io import fits
 
-from .core import AstroDataError
-
-LOGGER = logging.getLogger('AstroData Factory')
+LOGGER = logging.getLogger(__name__)
 
 
 def fits_opener(source):
     return fits.open(source, memmap=True)
+
+
+class AstroDataError(Exception):
+    pass
 
 
 class AstroDataFactory:

--- a/astrodata/factory.py
+++ b/astrodata/factory.py
@@ -1,14 +1,11 @@
 import logging
 import os
+from contextlib import contextmanager
 from copy import deepcopy
 
 from astropy.io import fits
 
 LOGGER = logging.getLogger(__name__)
-
-
-def fits_opener(source):
-    return fits.open(source, memmap=True)
 
 
 class AstroDataError(Exception):
@@ -18,23 +15,24 @@ class AstroDataError(Exception):
 class AstroDataFactory:
 
     _file_openers = (
-        fits_opener,
+        fits.open,
     )
 
     def __init__(self):
         self._registry = set()
 
     @staticmethod
+    @contextmanager
     def _openFile(source):
         """
-        Internal static method that takes a `source`, assuming that it is a
+        Internal static method that takes a ``source``, assuming that it is a
         string pointing to a file to be opened.
 
         If this is the case, it will try to open the file and return an
         instance of the appropriate native class to be able to manipulate it
         (eg. ``HDUList``).
 
-        If `source` is not a string, it will be returned verbatim, assuming
+        If ``source`` is not a string, it will be returned verbatim, assuming
         that it represents an already opened file.
 
         """
@@ -46,15 +44,20 @@ class AstroDataFactory:
             # try vs all handlers
             for func in AstroDataFactory._file_openers:
                 try:
-                    return func(source)
+                    fp = func(source)
+                    yield fp
                 except Exception:
                     # Just ignore the error. Assume that it is a not supported
                     # format and go for the next opener
                     pass
+                else:
+                    if hasattr(fp, 'close'):
+                        fp.close()
+                    return
             raise AstroDataError("No access, or not supported format for: {}"
                                  .format(source))
         else:
-            return source
+            yield source
 
     def addClass(self, cls):
         """
@@ -78,17 +81,18 @@ class AstroDataFactory:
         not possible to find a match
 
         """
-        opened = self._openFile(source)
         candidates = []
-        for adclass in self._registry:
-            try:
-                if adclass._matches_data(opened):
-                    candidates.append(adclass)
-            except Exception:  # Some problem opening this
-                pass
+        with self._openFile(source) as opened:
+            for adclass in self._registry:
+                try:
+                    if adclass._matches_data(opened):
+                        candidates.append(adclass)
+                except Exception:  # Some problem opening this
+                    pass
 
-        # For every candidate in the list, remove the ones that are base classes
-        # for other candidates. That way we keep only the more specific ones.
+        # For every candidate in the list, remove the ones that are base
+        # classes for other candidates. That way we keep only the more
+        # specific ones.
         final_candidates = []
         for cnd in candidates:
             if any(cnd in x.mro() for x in candidates if x != cnd):
@@ -100,7 +104,7 @@ class AstroDataFactory:
         elif not final_candidates:
             raise AstroDataError("No class matches this dataset")
 
-        return final_candidates[0].load(source)
+        return final_candidates[0].read(source)
 
     def createFromScratch(self, phu, extensions=None):
         """Creates an AstroData object from a collection of objects.

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -411,19 +411,6 @@ class FitsProviderProxy:
         self._provider._oper(self._provider._rdiv, operand, self._mapping)
         return self
 
-    def _crop_nd(self, nd, x1, y1, x2, y2):
-        # needed because __getattr__ breaks finding private methods in the
-        # parent class...
-        self._provider._crop_nd(nd, x1, y1, x2, y2)
-
-    def _crop_impl(self, x1, y1, x2, y2, nds=None):
-        # needed because __getattr__ breaks finding private methods in the
-        # parent class...
-        self._provider._crop_impl(x1, y1, x2, y2, nds=nds)
-
-    def crop(self, x1, y1, x2, y2):
-        self._crop_impl(x1, y1, x2, y2, self._mapped_nddata())
-
 
 class FitsProvider:
 
@@ -490,32 +477,6 @@ class FitsProvider:
 
     def __delitem__(self, idx):
         del self._nddata[idx]
-
-    def _crop_nd(self, nd, x1, y1, x2, y2):
-        nd.data = nd.data[y1:y2+1, x1:x2+1]
-        if nd.uncertainty is not None:
-            nd.uncertainty = nd.uncertainty[y1:y2+1, x1:x2+1]
-        if nd.mask is not None:
-            nd.mask = nd.mask[y1:y2+1, x1:x2+1]
-
-    def _crop_impl(self, x1, y1, x2, y2, nds=None):
-        if nds is None:
-            nds = self.nddata
-        # TODO: Consider cropping of objects in the meta section
-        for nd in nds:
-            orig_shape = nd.data.shape
-            self._crop_nd(nd, x1, y1, x2, y2)
-            for o in nd.meta['other'].values():
-                try:
-                    if o.shape == orig_shape:
-                        self._crop_nd(o, x1, y1, x2, y2)
-                except AttributeError:
-                    # No 'shape' attribute in the object. It's probably
-                    # not array-like
-                    pass
-
-    def crop(self, x1, y1, x2, y2):
-        self._crop_impl(x1, y1, x2, y2)
 
 
 def fits_ext_comp_key(ext):

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -514,57 +514,6 @@ class FitsProvider:
         except KeyError:
             raise AttributeError("'{}' is not a global table for this instance".format(attribute))
 
-    def _pixel_info(self, indices):
-        for idx, obj in ((n, self._nddata[k]) for (n, k) in enumerate(indices)):
-            other_objects = []
-            uncer = obj.uncertainty
-            fixed = (('variance', None if uncer is None else uncer), ('mask', obj.mask))
-            for name, other in fixed + tuple(sorted(obj.meta['other'].items())):
-                if other is not None:
-                    if isinstance(other, Table):
-                        other_objects.append(dict(
-                            attr=name, type='Table',
-                            dim=str((len(other), len(other.columns))),
-                            data_type='n/a'
-                        ))
-                    else:
-                        dim = ''
-                        if hasattr(other, 'dtype'):
-                            dt = other.dtype.name
-                            dim = str(other.shape)
-                        elif hasattr(other, 'data'):
-                            dt = other.data.dtype.name
-                            dim = str(other.data.shape)
-                        elif hasattr(other, 'array'):
-                            dt = other.array.dtype.name
-                            dim = str(other.array.shape)
-                        else:
-                            dt = 'unknown'
-                        other_objects.append(dict(
-                            attr=name, type=type(other).__name__,
-                            dim=dim, data_type = dt
-                        ))
-
-            yield dict(
-                    idx = '[{:2}]'.format(idx),
-                    main = dict(
-                        content = 'science',
-                        type = type(obj).__name__,
-                        dim = '({})'.format(', '.join(str(s) for s in obj.data.shape)),
-                        data_type = obj.data.dtype.name
-                    ),
-                    other = other_objects
-            )
-
-    def _other_info(self):
-        # NOTE: This covers tables, only. Study other cases before implementing a more general solution
-        if self._tables:
-            for name, table in sorted(self._tables.items()):
-                if type(table) is list:
-                    # This is not a free floating table
-                    continue
-                yield (name, 'Table', (len(table), len(table.columns)))
-
     def _slice(self, indices, multi=True):
         return FitsProviderProxy(self, indices, single=not multi)
 

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -588,7 +588,6 @@ def ad_to_hdulist(ad):
             except (ValueError, NotImplementedError) as e:
                 LOGGER.warning(e)
             else:
-                # HACK! Don't update the FITS WCS for an image
                 # Must delete keywords if image WCS has been downscaled
                 # from a higher number of dimensions
                 for i in range(1, 5):
@@ -604,7 +603,7 @@ def ad_to_hdulist(ad):
                 if 'APPROXIMATE' not in wcs_dict.get('FITS-WCS', ''):
                     wcs = None  # There's no need to create a WCS extension
 
-        hdul.append(new_imagehdu(ext.data, header))
+        hdul.append(new_imagehdu(ext.data, header, 'SCI'))
         if ext.uncertainty is not None:
             hdul.append(new_imagehdu(ext.uncertainty.array, header, 'VAR'))
         if ext.mask is not None:

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -266,7 +266,7 @@ def add_header_to_table(table):
     return header
 
 
-def _process_table(self, table, name=None, header=None):
+def _process_table(table, name=None, header=None):
     if isinstance(table, BinTableHDU):
         obj = Table(table.data, meta={'header': header or table.header})
         for i, col in enumerate(obj.columns, start=1):

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -500,7 +500,7 @@ def read_fits(cls, source, extname_parser=None):
     if 'ORIGNAME' not in hdulist[0].header and ad.orig_filename is not None:
         hdulist[0].header.set('ORIGNAME', ad.orig_filename,
                               'Original filename prior to processing')
-    ad.set_phu(hdulist[0].header)
+    ad.phu = hdulist[0].header
 
     seen = {hdulist[0]}
 

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -326,15 +326,6 @@ def update_header(headera, headerb):
 
 class FitsProviderProxy:
 
-    def __deepcopy__(self, memo):
-        return self._provider._clone(mapping=self._mapping)
-
-    def is_settable(self, attr):
-        if attr in {'path', 'filename'}:
-            return False
-
-        return self._provider.is_settable(attr)
-
     def __getattr__(self, attribute):
         if not attribute.startswith('_'):
             try:
@@ -433,33 +424,10 @@ class FitsProviderProxy:
     def crop(self, x1, y1, x2, y2):
         self._crop_impl(x1, y1, x2, y2, self._mapped_nddata())
 
-    def append(self, ext, name):
-        if not self.is_single:
-            # TODO: We could rethink this one, but leave it like that at the moment
-            raise TypeError("Can't append objects to non-single slices")
-        elif name is None:
-            raise TypeError("Can't append objects to a slice without an extension name")
-
-        target = self._mapped_nddata(0)
-        return self._provider.append(ext, name=name, add_to=target)
-
 
 class FitsProvider:
 
     default_extension = 'SCI'
-
-    def _clone(self, mapping=None):
-        if mapping is None:
-            mapping = range(len(self))
-
-        dp = FitsProvider()
-        dp._phu = deepcopy(self._phu)
-        for n in mapping:
-            dp.append(deepcopy(self._nddata[n]))
-        for t in self._tables.values():
-            dp.append(deepcopy(t))
-
-        return dp
 
     def _getattr_impl(self, attribute, nds):
         # Exposed objects are part of the normal object interface. We may have

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -15,6 +15,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.io.fits import (DELAYED, BinTableHDU, Column, FITS_rec, HDUList,
                              ImageHDU, PrimaryHDU, TableHDU)
+from astropy.nddata import NDData
 # NDDataRef is still not in the stable astropy, but this should be the one
 # we use in the future...
 # from astropy.nddata import NDData, NDDataRef as NDDataObject

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -485,26 +485,23 @@ def read_fits(cls, source, extname_parser=None):
     if 'ORIGNAME' not in hdulist[0].header and ad.orig_filename is not None:
         hdulist[0].header.set('ORIGNAME', ad.orig_filename,
                               'Original filename prior to processing')
+
     ad.phu = hdulist[0].header
-
     seen = {hdulist[0]}
-
     skip_names = {DEFAULT_EXTENSION, 'REFCAT', 'MDF'}
 
     def associated_extensions(ver):
-        for unit in hdulist:
-            header = unit.header
-            if header.get('EXTVER') == ver and header['EXTNAME'] not in skip_names:
-                yield unit
+        for hdu in hdulist:
+            if hdu.header.get('EXTVER') == ver and hdu.name not in skip_names:
+                yield hdu
 
-    sci_units = [x for x in hdulist[1:]
-                 if x.header.get('EXTNAME') == DEFAULT_EXTENSION]
+    sci_units = [hdu for hdu in hdulist[1:] if hdu.name == DEFAULT_EXTENSION]
 
-    for idx, unit in enumerate(sci_units):
-        seen.add(unit)
-        ver = unit.header.get('EXTVER', -1)
+    for idx, hdu in enumerate(sci_units):
+        seen.add(hdu)
+        ver = hdu.header.get('EXTVER', -1)
         parts = {
-            'data': unit,
+            'data': hdu,
             'uncertainty': None,
             'mask': None,
             'wcs': None,
@@ -513,7 +510,7 @@ def read_fits(cls, source, extname_parser=None):
 
         for extra_unit in associated_extensions(ver):
             seen.add(extra_unit)
-            name = extra_unit.header.get('EXTNAME')
+            name = extra_unit.name
             if name == 'DQ':
                 parts['mask'] = extra_unit
             elif name == 'VAR':

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -1734,68 +1734,8 @@ def windowedOp(func, sequence, kernel, shape=None, dtype=None,
 
 
 class AstroDataFits(AstroData):
+    """Keep this for now as other classes inherit from it."""
 
-    @classmethod
-    def load(cls, source):
-        """
-        Implementation of the abstract method `load`.
-
-        It takes an `HDUList` and returns a fully instantiated `AstroData` instance.
-        """
-
-        return cls(FitsLoader(FitsProvider).load(source))
-
-    @staticmethod
-    def _matches_data(dataprov):
-        # This one is trivial. As long as we get a FITS file...
-        return True
-
-    @property
-    def phu(self):
-        return self._dataprov.phu()
-
-    @property
-    def hdr(self):
-        return self._dataprov.hdr()
-
-    def info(self):
-        self._dataprov.info(self.tags)
-
-    def write(self, filename=None, overwrite=False):
-        if filename is None:
-            if self.path is None:
-                raise ValueError("A filename needs to be specified")
-            filename = self.path
-
-        hdulist = self._dataprov.to_hdulist()
-        hdulist.writeto(filename, overwrite=overwrite)
-
-    def extver(self, ver):
-        """
-        Get an extension using its EXTVER instead of the positional index
-        in this object.
-
-        Parameters
-        ----------
-        ver : int
-            The EXTVER for the desired extension
-
-        Returns
-        -------
-        A sliced object containing the desired extension
-
-        Raises
-        ------
-        IndexError
-            If the provided EXTVER doesn't exist
-        """
-        try:
-            if isinstance(ver, int):
-                return self[self._dataprov.extver_map()[ver]]
-            else:
-                raise ValueError("{} is not an integer EXTVER".format(ver))
-        except KeyError as e:
-            raise IndexError("EXTVER {} not found".format(e.args[0]))
 
 # ---------------------------------------------------------------------------
 # gWCS <-> FITS WCS helper functions go here

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -589,7 +589,8 @@ def read_fits(cls, source, extname_parser=None):
     return ad
 
 
-def write_fits(ad, filename, overwrite=False):
+def ad_to_hdulist(ad):
+    """Creates an HDUList from an AstroData object."""
     hdul = HDUList()
     hdul.append(PrimaryHDU(header=ad.phu, data=DELAYED))
 
@@ -647,6 +648,12 @@ def write_fits(ad, filename, overwrite=False):
         for name, table in sorted(ad._tables.items()):
             hdul.append(table_to_bintablehdu(table, extname=name))
 
+    return hdul
+
+
+def write_fits(ad, filename, overwrite=False):
+    """Writes the AstroData object to a FITS file."""
+    hdul = ad_to_hdulist(ad)
     hdul.writeto(filename, overwrite=overwrite)
 
 

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -590,7 +590,7 @@ def read_fits(cls, source, extname_parser=None):
 
 def write_fits(ad, filename, overwrite=False):
     hdul = HDUList()
-    hdul.append(PrimaryHDU(header=ad.phu(), data=DELAYED))
+    hdul.append(PrimaryHDU(header=ad.phu, data=DELAYED))
 
     for ext in ad._nddata:
         meta = ext.meta

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -921,9 +921,6 @@ class FitsProvider:
 
         return new_nddata
 
-    def _set_nddata(self, n, new_nddata):
-        self._nddata[n] = new_nddata
-
     def _append_table(self, new_table, name, header, add_to, reset_ver=True):
         tb = _process_table(new_table, name, header)
         hname = tb.meta['header'].get('EXTNAME') if name is None else name

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -456,7 +456,7 @@ def _prepare_hdulist(hdulist, default_extension='SCI', extname_parser=None):
 def read_fits(cls, source, extname_parser=None):
     """
     Takes either a string (with the path to a file) or an HDUList as input, and
-    tries to return a populated FitsProvider (or descendant) instance.
+    tries to return a populated AstroData (or descendant) instance.
 
     It will raise exceptions if the file is not found, or if there is no match
     for the HDUList, among the registered AstroData classes.

--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -8,13 +8,12 @@ import warnings
 from copy import deepcopy
 from functools import reduce
 
-from astropy.nddata import (NDData, NDSlicingMixin, NDArithmeticMixin,
-                            VarianceUncertainty)
-from astropy.io.fits import ImageHDU
-from astropy.modeling import models, Model
-
 import numpy as np
 
+from astropy.io.fits import ImageHDU
+from astropy.modeling import Model, models
+from astropy.nddata import (NDArithmeticMixin, NDData, NDSlicingMixin,
+                            VarianceUncertainty)
 from astropy.wcs import WCS
 from gwcs.wcs import WCS as gWCS
 
@@ -169,20 +168,22 @@ class NDAstroData(NDArithmeticMixin, NDSlicingMixin, NDData):
             self.uncertainty = uncertainty
 
     def __deepcopy__(self, memo):
-        new = self.__class__(self._data if is_lazy(self._data) else deepcopy(self.data, memo),
-                             self._uncertainty if is_lazy(self._uncertainty) else None,
-                             self._mask if is_lazy(self._mask) else deepcopy(self.mask, memo),
-                             deepcopy(self.wcs, memo), None, self.unit)
+        new = self.__class__(
+            self._data if is_lazy(self._data) else deepcopy(self.data, memo),
+            self._uncertainty if is_lazy(self._uncertainty) else None,
+            self._mask if is_lazy(self._mask) else deepcopy(self.mask, memo),
+            deepcopy(self.wcs, memo), None, self.unit
+        )
         new.meta = deepcopy(self.meta, memo)
         # Needed to avoid recursion because of uncertainty's weakref to self
         if not is_lazy(self._uncertainty):
             new.variance = deepcopy(self.variance)
         return new
 
-    def _arithmetic(self, operation, operand,
-                    propagate_uncertainties=True, handle_mask=np.bitwise_or,
-                    handle_meta=None, uncertainty_correlation=0,
-                    compare_wcs='first_found', **kwds):
+    def _arithmetic(self, operation, operand, propagate_uncertainties=True,
+                    handle_mask=np.bitwise_or, handle_meta=None,
+                    uncertainty_correlation=0, compare_wcs='first_found',
+                    **kwds):
         """
         Override the NDData method so that "bitwise_or" becomes the default
         operation to combine masks, rather than "logical_or"
@@ -258,13 +259,14 @@ class NDAstroData(NDArithmeticMixin, NDSlicingMixin, NDData):
     @property
     def window(self):
         """
-        Interface to access a section of the data, using lazy access whenever possible.
+        Interface to access a section of the data, using lazy access whenever
+        possible.
 
         Returns
         --------
-        An instance of ``NDWindowing``, which provides ``__getitem__``, to allow the use
-        of square brackets when specifying the window. Ultimately, an
-        ``NDWindowingAstrodata`` instance is returned
+        An instance of ``NDWindowing``, which provides ``__getitem__``,
+        to allow the use of square brackets when specifying the window.
+        Ultimately, an ``NDWindowingAstrodata`` instance is returned.
 
         Examples
         ---------

--- a/astrodata/provenance.py
+++ b/astrodata/provenance.py
@@ -7,18 +7,21 @@ PROVENANCE_DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 def add_provenance(ad, filename, md5, primitive, timestamp=None):
     """
-    Add the given `Provenance` entry to the full set of provenance records on this object.
+    Add the given provenance entry to the full set of provenance records on
+    this object.
 
-    Provenance is not added if the incoming md5 is None or ''.  These indicate source data
-    for the provenance that are not on disk, so not useful as provenance.
+    Provenance is not added if the incoming md5 is None or ''.  These indicate
+    source data for the provenance that are not on disk, so not useful as
+    provenance.
 
-    Args
-    -----
-    value : `Provenance` to add
+    Parameters
+    ----------
+    ad : `astrodata.AstroData`
+    filename : str
+    md5 : str
+    primitive : str
+    timestamp : `datetime.datetime`
 
-    Returns
-    --------
-    none
     """
     if md5 is None or md5 == '':
         # not a real input, we can ignore this one
@@ -41,9 +44,10 @@ def add_provenance(ad, filename, md5, primitive, timestamp=None):
         filename_data = [filename]
         md5_data = [md5]
         provenance_added_by_data = [primitive]
-        ad.PROVENANCE = Table([timestamp_data, filename_data, md5_data, provenance_added_by_data],
-                              names=('timestamp', 'filename', 'md5', 'provenance_added_by'),
-                              dtype=('S28', 'S128', 'S128', 'S128'))
+        ad.PROVENANCE = Table(
+            [timestamp_data, filename_data, md5_data, provenance_added_by_data],
+            names=('timestamp', 'filename', 'md5', 'provenance_added_by'),
+            dtype=('S28', 'S128', 'S128', 'S128'))
     else:
         provenance = ad.PROVENANCE
         provenance.add_row((timestamp, filename, md5, primitive))
@@ -51,19 +55,22 @@ def add_provenance(ad, filename, md5, primitive, timestamp=None):
 
 def add_provenance_history(ad, timestamp_start, timestamp_stop, primitive, args):
     """
-    Add the given ProvenanceHistory entry to the full set of history records on this object.
+    Add the given ProvenanceHistory entry to the full set of history records
+    on this object.
 
-    Args
-    -----
-    ad : `AstroData` to add history record to
-    timestamp_start : `datetime` of the start of this operation
-    timestamp_stop : `datetime` of the end of this operation
-    primitive : `str` name of the primitive performed
-    args : `str` arguments used for the primitive call
+    Parameters
+    ----------
+    ad : `astrodata.AstroData`
+        AstroData object to add history record to.
+    timestamp_start : `datetime.datetime`
+        Date of the start of this operation.
+    timestamp_stop : `datetime.datetime`
+        Date of the end of this operation.
+    primitive : str
+        Name of the primitive performed.
+    args : str
+        Arguments used for the primitive call.
 
-    Returns
-    --------
-    none
     """
     if hasattr(ad, 'PROVENANCE_HISTORY'):
         for row in ad.PROVENANCE_HISTORY:
@@ -94,10 +101,10 @@ def add_provenance_history(ad, timestamp_start, timestamp_stop, primitive, args)
     args_arr.append(args)
 
     dtype = ("S28", "S28", "S128", "S%d" % colsize)
-    ad.append(Table([timestamp_start_arr, timestamp_stop_arr, primitive_arr, args_arr],
-                    names=('timestamp_start', 'timestamp_stop',
-                           'primitive', 'args'),
-                    dtype=dtype), name="PROVENANCE_HISTORY")
+    ad.append(Table(
+        [timestamp_start_arr, timestamp_stop_arr, primitive_arr, args_arr],
+        names=('timestamp_start', 'timestamp_stop', 'primitive', 'args'),
+        dtype=dtype), name="PROVENANCE_HISTORY")
 
 
 def clone_provenance(provenance_data, ad):
@@ -109,16 +116,15 @@ def clone_provenance(provenance_data, ad):
     original provenance and provenance_history information.  It duplicates
     the provenance data into the outgoing `AstroData` ad object.
 
-    Args
-    -----
-    provenance_data : pointer to the `AstroData` table with the provenance
-        information.
-        *Note* this may be the output `AstroData` as well, so we need to handle that.
-    ad : outgoing `AstroData` object to add provenance data to
+    Parameters
+    ----------
+    provenance_data :
+        Pointer to the `~astrodata.AstroData` table with the provenance
+        information.  *Note* this may be the output `~astrodata.AstroData`
+        as well, so we need to handle that.
+    ad : `astrodata.AstroData`
+        Outgoing `~astrodata.AstroData` object to add provenance data to.
 
-    Returns
-    --------
-    none
 
     """
     pd = [(prov[1], prov[2], prov[3], prov[0]) for prov in provenance_data]
@@ -135,16 +141,18 @@ def clone_provenance_history(provenance_history_data, ad):
     original provenance and provenance_history information.  It duplicates
     the provenance data into the outgoing `AstroData` ad object.
 
-    Args
-    -----
-    provenance_history_data : pointer to the `AstroData` table with the history information.
-        *Note* this may be the output `AstroData` as well, so we need to handle that.
-    ad : outgoing `AstroData` object to add provenance history data to
+    Parameters
+    ----------
+    provenance_history_data :
+        pointer to the `AstroData` table with the history information.
+        *Note* this may be the output `~astrodata.AstroData` as well, so we
+        need to handle that.
+    ad : `astrodata.AstroData`
+        Outgoing `~astrodata.AstroData` object to add provenance history data
+        to.
 
-    Returns
-    --------
-    none
     """
-    phd = [(prov_hist[0], prov_hist[1], prov_hist[2], prov_hist[3]) for prov_hist in provenance_history_data]
+    phd = [(prov_hist[0], prov_hist[1], prov_hist[2], prov_hist[3])
+           for prov_hist in provenance_history_data]
     for ph in phd:
         add_provenance_history(ad, ph[0], ph[1], ph[2], ph[3])

--- a/astrodata/tests/test_core.py
+++ b/astrodata/tests/test_core.py
@@ -76,7 +76,6 @@ def test_can_append_an_image_hdu_object_to_an_astrodata_object():
     assert ad[1].data is hdu.data
 
 
-@pytest.mark.dragons_remote_data
 def test_attributes(ad1):
     assert ad1[0].shape == SHAPE
 
@@ -90,7 +89,6 @@ def test_attributes(ad1):
     assert ad1.object() == 'M42'
 
 
-@pytest.mark.dragons_remote_data
 @pytest.mark.parametrize('op, res, res2', [
     (operator.add, 3, 3),
     (operator.sub, -1, 1),
@@ -122,7 +120,6 @@ def test_arithmetic(op, res, res2, ad1, ad2):
     assert_array_equal(result.data, res2)
 
 
-@pytest.mark.dragons_remote_data
 @pytest.mark.parametrize('op, res, res2', [
     (operator.iadd, 3, 3),
     (operator.isub, -1, 1),
@@ -203,7 +200,6 @@ def test_arithmetic_inplace_multiple_ext(op, res, ad1):
         assert_array_equal(result.data, res[i])
 
 
-@pytest.mark.dragons_remote_data
 @pytest.mark.parametrize('op, arg, res', [('add', 100, 101),
                                           ('subtract', 100, -99),
                                           ('multiply', 3, 3),
@@ -276,7 +272,6 @@ def test_write_and_read(tmpdir, capsys):
     assert_array_equal(ad[0].nddata.mask[0], nd.mask[0])
 
 
-@pytest.mark.dragons_remote_data
 def test_reset(ad1):
     data = np.ones(SHAPE) + 3
     with pytest.raises(ValueError):

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 import astrodata
-from astrodata.fits import AstroDataFitsDeprecationWarning
+from astrodata.utils import AstroDataFitsDeprecationWarning
 from astrodata.nddata import ADVarianceUncertainty, NDAstroData
 from astrodata.testing import download_from_archive, compare_models
 import astropy

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -462,7 +462,7 @@ def test_attributes(GSAOI_DARK):
     assert all(isinstance(nd, NDAstroData) for nd in ad.nddata)
     assert [nd.shape for nd in ad.nddata] == [(2048, 2048)] * 4
 
-    match = 'Trying to assign to a non-sliced AstroData object'
+    match = "Trying to assign to an AstroData object that is not a single slice"
     with pytest.raises(ValueError, match=match):
         ad.data = 1
     with pytest.raises(ValueError, match=match):

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -882,7 +882,7 @@ def test_round_trip_gwcs(tmpdir):
     ad1[0].nddata.wcs = WCS([(det_frame, distrans),
                              (dref_frame, wavtrans),
                              (rss_frame, None)
-                            ])
+                             ])
 
     # Save & re-load the AstroData instance with its new WCS attribute:
     testfile = str(tmpdir.join('round_trip_gwcs.fits'))

--- a/astrodata/tests/test_tags.py
+++ b/astrodata/tests/test_tags.py
@@ -130,7 +130,7 @@ def test_info(testfile, capsys):
     out = captured.out.splitlines()
     assert out[0].endswith('fakebias.fits')
     assert out[1:] == [
-        'Tags: DARK MYINSTRUMENT ',
+        'Tags: DARK MYINSTRUMENT',
         '',
         'Pixels Extensions',
         'Index  Content                  Type              Dimensions     Format',
@@ -147,7 +147,7 @@ def test_info(testfile, capsys):
     out = captured.out.splitlines()
     assert out[0].endswith('fakebias.fits')
     assert out[1:] == [
-        'Tags: DARK MYINSTRUMENT ',
+        'Tags: DARK MYINSTRUMENT',
         '',
         'Pixels Extensions',
         'Index  Content                  Type              Dimensions     Format',

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -1,0 +1,53 @@
+import inspect
+import warnings
+from functools import wraps
+from traceback import format_stack
+import numpy as np
+
+INTEGER_TYPES = (int, np.integer)
+
+
+# FIXME: Should be AstroDataDeprecationWarning ?
+class AstroDataFitsDeprecationWarning(DeprecationWarning):
+    pass
+
+
+warnings.simplefilter("always", AstroDataFitsDeprecationWarning)
+
+
+def deprecated(reason):
+    def decorator_wrapper(fn):
+        @wraps(fn)
+        def wrapper(*args, **kw):
+            current_source = '|'.join(format_stack(inspect.currentframe()))
+            if current_source not in wrapper.seen:
+                wrapper.seen.add(current_source)
+                warnings.warn(reason, AstroDataFitsDeprecationWarning)
+            return fn(*args, **kw)
+        wrapper.seen = set()
+        return wrapper
+    return decorator_wrapper
+
+
+def normalize_indices(slc, nitems):
+    multiple = True
+    if isinstance(slc, slice):
+        start, stop, step = slc.indices(nitems)
+        indices = list(range(start, stop, step))
+    elif (isinstance(slc, INTEGER_TYPES) or
+          (isinstance(slc, tuple) and
+           all(isinstance(i, INTEGER_TYPES) for i in slc))):
+        if isinstance(slc, INTEGER_TYPES):
+            slc = (int(slc),)   # slc's type m
+            multiple = False
+        else:
+            multiple = True
+        # Normalize negative indices...
+        indices = [(x if x >= 0 else nitems + x) for x in slc]
+    else:
+        raise ValueError("Invalid index: {}".format(slc))
+
+    if any(i >= nitems for i in indices):
+        raise IndexError("Index out of range")
+
+    return indices, multiple

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -75,15 +75,15 @@ class TagSet(namedtuple('TagSet', 'add remove blocked_by blocks if_present')):
 
     Attributes
     ----------
-    add : set of str, or None
+    add : set of str, optional
         Tags to be added to the global set
-    remove : set of str, or None
+    remove : set of str, optional
         Tags to be removed from the global set
-    blocked_by : set of str, or None
+    blocked_by : set of str, optional
         Tags that will prevent this TagSet from being applied
-    blocks : set of str, or None
+    blocks : set of str, optional
         Other TagSets containing these won't be applied
-    if_present : set of str, or None
+    if_present : set of str, optional
         This TagSet will be applied only *all* of these tags are present
 
     Examples

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -1,10 +1,16 @@
 import inspect
 import warnings
+from collections import namedtuple
 from functools import wraps
 from traceback import format_stack
+
 import numpy as np
 
 INTEGER_TYPES = (int, np.integer)
+
+__all__ = ('deprecated', 'normalize_indices', 'TagSet',
+           'AstroDataFitsDeprecationWarning', 'returns_list',
+           'astro_data_tag', 'astro_data_descriptor')
 
 
 # FIXME: Should be AstroDataDeprecationWarning ?
@@ -51,3 +57,152 @@ def normalize_indices(slc, nitems):
         raise IndexError("Index out of range")
 
     return indices, multiple
+
+
+class TagSet(namedtuple('TagSet', 'add remove blocked_by blocks if_present')):
+    """
+    Named tuple that is used by tag methods to return which actions should be
+    performed on a tag set. All the attributes are optional, and any
+    combination of them can be used, allowing to create complex tag structures.
+    Read the documentation on the tag-generating algorithm if you want to
+    better understand the interactions.
+
+    The simplest TagSet, though, tends to just add tags to the global set.
+
+    It can be initialized by position, like any other tuple (the order of the
+    arguments is the one in which the attributes are listed below). It can
+    also be initialized by name.
+
+    Attributes
+    ----------
+    add : set of str, or None
+        Tags to be added to the global set
+    remove : set of str, or None
+        Tags to be removed from the global set
+    blocked_by : set of str, or None
+        Tags that will prevent this TagSet from being applied
+    blocks : set of str, or None
+        Other TagSets containing these won't be applied
+    if_present : set of str, or None
+        This TagSet will be applied only *all* of these tags are present
+
+    Examples
+    ---------
+    >>> TagSet()
+    TagSet(add=set(), remove=set(), blocked_by=set(), blocks=set(), if_present=set())
+    >>> TagSet({'BIAS', 'CAL'})
+    TagSet(add={'BIAS', 'CAL'}, remove=set(), blocked_by=set(), blocks=set(), if_present=set())
+    >>> TagSet(remove={'BIAS', 'CAL'})
+    TagSet(add=set(), remove={'BIAS', 'CAL'}, blocked_by=set(), blocks=set(), if_present=set())
+
+    """
+    def __new__(cls, add=None, remove=None, blocked_by=None, blocks=None,
+                if_present=None):
+        return super().__new__(cls, add or set(),
+                               remove or set(),
+                               blocked_by or set(),
+                               blocks or set(),
+                               if_present or set())
+
+
+def astro_data_descriptor(fn):
+    """
+    Decorator that will mark a class method as an AstroData descriptor.
+    Useful to produce list of descriptors, for example.
+
+    If used in combination with other decorators, this one *must* be the
+    one on the top (ie. the last one applying). It doesn't modify the
+    method in any other way.
+
+    Args
+    -----
+    fn : method
+        The method to be decorated
+
+    Returns
+    --------
+    The tagged method (not a wrapper)
+    """
+    fn.descriptor_method = True
+    return fn
+
+
+def returns_list(fn):
+    """
+    Decorator to ensure that descriptors that should return a list (of one
+    value per extension) only returns single values when operating on
+    single slices; and vice versa.
+
+    This is a common case, and you can use the decorator to simplify the
+    logic of your descriptors.
+
+    Args
+    -----
+    fn : method
+        The method to be decorated
+
+    Returns
+    --------
+    A function
+    """
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        ret = fn(self, *args, **kwargs)
+        if self.is_single:
+            if isinstance(ret, list):
+                # TODO: log a warning if the list is >1 element
+                if len(ret) > 1:
+                    pass
+                return ret[0]
+            else:
+                return ret
+        else:
+            if isinstance(ret, list):
+                if len(ret) == len(self):
+                    return ret
+                else:
+                    raise IndexError(
+                        "Incompatible numbers of extensions and elements in {}"
+                        .format(fn.__name__))
+            else:
+                return [ret] * len(self)
+    return wrapper
+
+
+def astro_data_tag(fn):
+    """
+    Decorator that marks methods of an `AstroData` derived class as part of the
+    tag-producing system.
+
+    It wraps the method around a function that will ensure a consistent return
+    value: the wrapped method can return any sequence of sequences of strings,
+    and they will be converted to a TagSet. If the wrapped method
+    returns None, it will be turned into an empty TagSet.
+
+    Args
+    -----
+    fn : method
+        The method to be decorated
+
+    Returns
+    --------
+    A wrapper function
+    """
+    @wraps(fn)
+    def wrapper(self):
+        try:
+            ret = fn(self)
+            if ret is not None:
+                if not isinstance(ret, TagSet):
+                    raise TypeError("Tag function {} didn't return a TagSet"
+                                    .format(fn.__name__))
+
+                return TagSet(*tuple(set(s) for s in ret))
+        except KeyError:
+            pass
+
+        # Return empty TagSet for the "doesn't apply" case
+        return TagSet()
+
+    wrapper.tag_method = True
+    return wrapper

--- a/astrodata/utils.py
+++ b/astrodata/utils.py
@@ -8,9 +8,9 @@ import numpy as np
 
 INTEGER_TYPES = (int, np.integer)
 
-__all__ = ('deprecated', 'normalize_indices', 'TagSet',
-           'AstroDataFitsDeprecationWarning', 'returns_list',
-           'astro_data_tag', 'astro_data_descriptor')
+__all__ = ('assign_only_single_slice', 'astro_data_descriptor',
+           'AstroDataFitsDeprecationWarning', 'astro_data_tag', 'deprecated',
+           'normalize_indices', 'returns_list', 'TagSet')
 
 
 # FIXME: Should be AstroDataDeprecationWarning ?
@@ -166,6 +166,17 @@ def returns_list(fn):
                         .format(fn.__name__))
             else:
                 return [ret] * len(self)
+    return wrapper
+
+
+def assign_only_single_slice(fn):
+    """Raise `ValueError` if assigning to a non-single slice."""
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        if not self.is_single:
+            raise ValueError("Trying to assign to an AstroData object that "
+                             "is not a single slice")
+        return fn(self, *args, **kwargs)
     return wrapper
 
 

--- a/astrodata/wcs.py
+++ b/astrodata/wcs.py
@@ -1,24 +1,23 @@
-import numpy as np
+import functools
 import re
+from collections import namedtuple
 
-from gwcs import coordinate_frames as cf
-from gwcs import utils as gwutils
+import numpy as np
 from astropy import coordinates as coord
 from astropy import units as u
-from astropy.modeling import core, models, projections
 from astropy.io import fits
-
+from astropy.modeling import core, models, projections
+from gwcs import coordinate_frames as cf
+from gwcs import utils as gwutils
+from gwcs.utils import sky_pairs, specsystems
 from gwcs.wcs import WCS as gWCS
 
-import functools
-from collections import namedtuple
 AffineMatrices = namedtuple("AffineMatrices", "matrix offset")
-
-from gwcs.utils import sky_pairs, specsystems
 
 #-----------------------------------------------------------------------------
 # FITS-WCS -> gWCS
 #-----------------------------------------------------------------------------
+
 
 def fitswcs_to_gwcs(hdr):
     """
@@ -96,14 +95,16 @@ def gwcs_to_fits(ndd, hdr=None):
 
     Parameters
     ----------
-    ndd: NDData
+    ndd : `astropy.nddata.NDData`
         The NDData whose wcs attribute we want converted
-    hdr: fits.Header
+    hdr : `astropy.io.fits.Header`
         A Header object that may contain some useful keywords
 
     Returns
     -------
-    dict: values to insert into the FITS header to express this WCS
+    dict
+        values to insert into the FITS header to express this WCS
+
     """
     if hdr is None:
         hdr = {}
@@ -239,14 +240,16 @@ def calculate_affine_matrices(func, shape):
 
     Parameters
     ----------
-    func: callable
+    func : callable
         function that maps input->output coordinates
-    shape: sequence
+    shape : sequence
         shape to use for fiducial points
 
     Returns
     -------
-        AffineMatrices(array, array): affine matrix and offset
+    AffineMatrices(array, array)
+        affine matrix and offset
+
     """
     indim = len(shape)
     try:
@@ -277,7 +280,7 @@ def read_wcs_from_header(header):
 
     Parameters
     ----------
-    header : astropy.io.fits.Header
+    header : `astropy.io.fits.Header`
         FITS Header with WCS information.
 
     Returns
@@ -343,12 +346,12 @@ def get_axes(header):
 
     Parameters
     ----------
-    header : astropy.io.fits.Header or dict
+    header : `astropy.io.fits.Header` or dict
         FITS Header (or dict) with basic WCS information.
 
     Returns
     -------
-    sky_inmap, spectral_inmap, unknown : lists
+    sky_inmap, spectral_inmap, unknown : list
         indices in the output representing sky and spectral coordinates.
 
     """
@@ -409,12 +412,12 @@ def _get_contributing_axes(wcs_info, world_axes):
     ----------
     wcs_info : dict
         dict of WCS information
-    world_axes : int/iterable of ints
+    world_axes : int or iterable of int
         axes in the world coordinate system
 
     Returns
     -------
-    axes: list
+    axes : list
         axes whose pixel coordinates affect the output axis/axes
     """
     cd = wcs_info['CD']
@@ -432,7 +435,7 @@ def make_fitswcs_transform(header):
 
     Parameters
     ----------
-    header : astropy.io.fits.Header or dict
+    header : `astropy.io.fits.Header` or dict
         FITS Header (or dict) with basic WCS information
 
     """
@@ -479,7 +482,7 @@ def fitswcs_image(header):
 
     Parameters
     ----------
-    header : astropy.io.fits.Header or dict
+    header : `astropy.io.fits.Header` or dict
         FITS Header or dict with basic FITS WCS keywords.
 
     """
@@ -544,7 +547,7 @@ def fitswcs_linear(header):
 
     Parameters
     ----------
-    header : astropy.io.fits.Header or dict
+    header : `astropy.io.fits.Header` or dict
         FITS Header or dict with basic FITS WCS keywords.
 
     """

--- a/gemini_instruments/gmos/pixel_functions.py
+++ b/gemini_instruments/gmos/pixel_functions.py
@@ -13,6 +13,8 @@ import numpy as np
 from datetime import date
 from gemini_instruments.gmos import lookup
 # ------------------------------------------------------------------------------
+
+
 def get_bias_level(adinput=None, estimate=True):
     # Temporarily only do this for GMOS data. It would be better if we could do
     # checks on oberving band / type (e.g., OPTICAL / IR) and have this
@@ -22,14 +24,15 @@ def get_bias_level(adinput=None, estimate=True):
     __ALLOWED_TYPES__ = ["GMOS"]
     if not set(__ALLOWED_TYPES__).issubset(adinput.tags):
         msg = "{}.{} only works for {} data".format(__name__,
-                                                       "get_bias_level",
-                                                       __ALLOWED_TYPES__)
+                                                    "get_bias_level",
+                                                    __ALLOWED_TYPES__)
         raise NotImplementedError(msg)
     elif estimate:
         bias_level = _get_bias_level_estimate(adinput=adinput)
     else:
         bias_level = _get_bias_level(adinput=adinput)
     return bias_level
+
 
 def _get_bias_level(adinput=None):
     """
@@ -89,12 +92,13 @@ def _get_bias_level(adinput=None):
             bias_level.append(np.median(overscan_data))
 
         # Turn single-element list into a value if sent a single-extension slice
-        if adinput._single:
+        if adinput.is_single:
             bias_level = bias_level[0]
     else:
         bias_level = _get_bias_level_estimate(adinput=adinput)
 
     return bias_level
+
 
 def _get_bias_level_estimate(adinput=None):
     """

--- a/gemini_instruments/gpi/adclass.py
+++ b/gemini_instruments/gpi/adclass.py
@@ -1,27 +1,24 @@
-import re
-
-from astrodata import astro_data_tag, astro_data_descriptor, returns_list, TagSet
-from astrodata.fits import read_fits
+from astrodata import astro_data_tag, astro_data_descriptor, TagSet
 from ..gemini import AstroDataGemini
-from .. import gmu
+
 
 class AstroDataGpi(AstroDataGemini):
 
-    __keyword_dict = dict(array_section = 'DATASEC',
-                          detector_section = 'DATASEC',
-                          exposure_time = 'ITIME',
-                          filter = 'IFSFILT',
-                          focal_plane_mask = 'OCCULTER',
-                          pupil_mask = 'APODIZER')
+    __keyword_dict = dict(array_section='DATASEC',
+                          detector_section='DATASEC',
+                          exposure_time='ITIME',
+                          filter='IFSFILT',
+                          focal_plane_mask='OCCULTER',
+                          pupil_mask='APODIZER')
 
     @classmethod
-    def load(cls, source):
+    def read(cls, source):
         def gpi_parser(hdu):
             if hdu.header.get('EXTNAME') == 'DQ' and hdu.header.get('EXTVER') == 3:
                 hdu.header['EXTNAME'] = ('SCI', 'BPM renamed by AstroData')
                 hdu.header['EXTVER'] = (int(2), 'BPM renamed by AstroData')
 
-        return read_fits(source, extname_parser=gpi_parser)
+        return super().read(source, extname_parser=gpi_parser)
 
     @staticmethod
     def _matches_data(source):

--- a/gemini_instruments/gpi/adclass.py
+++ b/gemini_instruments/gpi/adclass.py
@@ -1,7 +1,7 @@
 import re
 
 from astrodata import astro_data_tag, astro_data_descriptor, returns_list, TagSet
-from astrodata.fits import FitsLoader, FitsProvider
+from astrodata.fits import read_fits
 from ..gemini import AstroDataGemini
 from .. import gmu
 
@@ -21,8 +21,7 @@ class AstroDataGpi(AstroDataGemini):
                 hdu.header['EXTNAME'] = ('SCI', 'BPM renamed by AstroData')
                 hdu.header['EXTVER'] = (int(2), 'BPM renamed by AstroData')
 
-        return cls(FitsLoader(FitsProvider).load(source, extname_parser=gpi_parser))
-
+        return read_fits(source, extname_parser=gpi_parser)
 
     @staticmethod
     def _matches_data(source):

--- a/gemini_instruments/skycam/adclass.py
+++ b/gemini_instruments/skycam/adclass.py
@@ -5,16 +5,8 @@
 #                                                             gemini_instruments
 #                                                              skycam.adclass.py
 # ------------------------------------------------------------------------------
-import datetime
-import dateutil.parser
 
-from astrodata import astro_data_tag
-from astrodata import astro_data_descriptor
-from astrodata import returns_list
-from astrodata import TagSet
-
-from astrodata.fits import FitsLoader
-from astrodata.fits import FitsProvider
+from astrodata import astro_data_tag, astro_data_descriptor, TagSet
 
 from ..gemini import AstroDataGemini
 

--- a/gemini_instruments/texes/adclass.py
+++ b/gemini_instruments/texes/adclass.py
@@ -7,11 +7,8 @@
 # ------------------------------------------------------------------------------
 from astrodata import astro_data_tag
 from astrodata import astro_data_descriptor
-from astrodata import returns_list
 from astrodata import TagSet
-
-from astrodata.fits import FitsLoader
-from astrodata.fits import FitsProvider
+from astrodata.fits import read_fits
 
 from ..gemini import AstroDataGemini
 
@@ -42,7 +39,7 @@ class AstroDataTexes(AstroDataGemini):
                 hdu.header.set('EXTVER', 1, 'Versioned by AstroData',
                                after='EXTNAME')
 
-        return cls(FitsLoader(FitsProvider).load(source, extname_parser=texes_parser))
+        return read_fits(source, extname_parser=texes_parser)
 
     @staticmethod
     def _matches_data(source):
@@ -85,7 +82,7 @@ class AstroDataTexes(AstroDataGemini):
     @astro_data_descriptor
     def observation_type(self):
         return self.phu.get('OBSTYPE').upper()
-    
+
     @astro_data_descriptor
     def ra(self):
         return self.phu.get(self._keyword_for('ra'))
@@ -94,4 +91,4 @@ class AstroDataTexes(AstroDataGemini):
     def dec(self):
         return self.phu.get(self._keyword_for('dec'))
 
-    
+

--- a/gemini_instruments/texes/adclass.py
+++ b/gemini_instruments/texes/adclass.py
@@ -8,20 +8,21 @@
 from astrodata import astro_data_tag
 from astrodata import astro_data_descriptor
 from astrodata import TagSet
-from astrodata.fits import read_fits
 
 from ..gemini import AstroDataGemini
 
 # ------------------------------------------------------------------------------
+
+
 class AstroDataTexes(AstroDataGemini):
     __keyword_dict = dict(
-        ra = 'RA',
-        dec = 'DEC',
-        target_ra = 'TARGRA',
-        target_dec = 'TARGDEC',
-        exposure_time = 'OBSTIME',
-        observation_type = 'OBSTYPE',
-        )
+        ra='RA',
+        dec='DEC',
+        target_ra='TARGRA',
+        target_dec='TARGDEC',
+        exposure_time='OBSTIME',
+        observation_type='OBSTYPE',
+    )
 
     @classmethod
     def load(cls, source):
@@ -29,17 +30,17 @@ class AstroDataTexes(AstroDataGemini):
             xnam, xver = hdu.header.get('EXTNAME'), hdu.header.get('EXTVER')
             if 'RAWFRAME' in [xnam] and xver:
                 hdu.header.set('EXTNAME0', xnam,
-                               'EXTNAME Orig (AstroData)',before='EXTNAME')
+                               'EXTNAME Orig (AstroData)', before='EXTNAME')
                 hdu.header.set('EXTNAME', 'SCI', 'Renamed by AstroData')
             elif 'SCAN-FRAME' in [xnam] and xver:
                 hdu.header.set('EXTNAME0', xnam,
-                               'EXTNAME Orig (AstroData)',before='EXTNAME')
+                               'EXTNAME Orig (AstroData)', before='EXTNAME')
                 hdu.header.set('EXTNAME', 'SCI', 'Renamed by AstroData')
             elif xnam and not xver:
                 hdu.header.set('EXTVER', 1, 'Versioned by AstroData',
                                after='EXTNAME')
 
-        return read_fits(source, extname_parser=texes_parser)
+        return super().read(source, extname_parser=texes_parser)
 
     @staticmethod
     def _matches_data(source):
@@ -90,5 +91,3 @@ class AstroDataTexes(AstroDataGemini):
     @astro_data_descriptor
     def dec(self):
         return self.phu.get(self._keyword_for('dec'))
-
-

--- a/geminidr/gmos/primitives_gmos.py
+++ b/geminidr/gmos/primitives_gmos.py
@@ -6,23 +6,18 @@
 import os
 from importlib import import_module
 
-import astrodata
-import gemini_instruments
-
+from gemini_instruments.gmos.pixel_functions import get_bias_level
+from geminidr.core import CCD
+# from gempy.scripts.gmoss_fix_headers import correct_headers
 # from gempy.gemini.eti import gmosaiceti
 from gempy.gemini import gemini_tools as gt
-# from gempy.scripts.gmoss_fix_headers import correct_headers
-# from gempy.gemini import hdr_fixing as hdrfix
+from recipe_system.utils.decorators import parameter_override
 
-from geminidr.core import CCD
 from ..gemini.primitives_gemini import Gemini
 from . import parameters_gmos
 from .lookups import maskdb
 
-from gemini_instruments.gmos.pixel_functions import get_bias_level
 
-from recipe_system.utils.decorators import parameter_override
-# ------------------------------------------------------------------------------
 @parameter_override
 class GMOS(Gemini, CCD):
     """
@@ -70,7 +65,7 @@ class GMOS(Gemini, CCD):
             #     #     correct_image_extensions=Flase
             #     # As does the DATE-OBS but as this seemed to break even after
             #     # apparently being fixed, still perform this check. - MS
-            #     hdulist = ad.to_hdulist()
+            #     hdulist = ad_to_hdulist(ad)
             #     # correct_headers(hdulist, logger=log,
             #     #                 correct_image_extensions=False)
             #     # When we create the new AD object, it needs to retain the

--- a/gempy/gemini/eti/sextractoretifile.py
+++ b/gempy/gemini/eti/sextractoretifile.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 
+from astrodata.fits import ad_to_hdulist
 from gempy.eti_core.etifile import ETIFile
 
 # Move this to a more central place
@@ -49,12 +50,12 @@ class SExtractorETIFile(ETIFile):
         filename = os.path.join(self.directory, PREFIX + self.name + SUFFIX)
         hdulist = fits.HDUList()
 
-        # By using the to_hdulist() method, we write the current gWCS
-        # TODO: to_hdulist() method writes entire parent AD object, not just
-        # the single slice we want
+        # By using ad_to_hdulist(), we write the current gWCS
+        # TODO: ad_to_hdulist() also writes a PrimaryHDU and the WCS table so
+        # we need to find the data hdu in the list
         extver = self.ext.hdr['EXTVER']
-        for hdu in self.ext.to_hdulist():
-            if hdu.header.get('EXTNAME') in ('SCI', 'DQ') and hdu.header['EXTVER'] == extver:
+        for hdu in ad_to_hdulist(self.ext):
+            if hdu.name in ('SCI', 'DQ') and hdu.header['EXTVER'] == extver:
                 hdulist.append(hdu)
 
         # Replace SCI with bitmasked data, and DQ as int16

--- a/gempy/scripts/typewalk.py
+++ b/gempy/scripts/typewalk.py
@@ -49,7 +49,7 @@ from importlib import import_module
 import astrodata
 import gemini_instruments
 
-from astrodata.core import AstroDataError
+from astrodata import AstroDataError
 
 # ------------------------------------------------------------------------------
 batchno = 100
@@ -176,7 +176,7 @@ class DataSpider:
 
     """
     def typewalk(self, directory=os.getcwd(), only=None, filemask=None,
-                 or_logic=False, outfile=None, stayTop=False, batchnum=100, 
+                 or_logic=False, outfile=None, stayTop=False, batchnum=100,
                  xtypes=None, adpkg=None):
         """
         Recursively walk <directory> and put type information to stdout

--- a/gempy/utils/showrecipes.py
+++ b/gempy/utils/showrecipes.py
@@ -9,7 +9,7 @@ import astrodata
 import gemini_instruments
 import geminidr
 
-from astrodata.core import AstroDataError
+from astrodata import AstroDataError
 from recipe_system.utils.errors import ModeError
 from recipe_system.utils.errors import RecipeNotFound
 from recipe_system.mappers.recipeMapper import RecipeMapper

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -23,7 +23,7 @@ import gemini_instruments
 
 from gempy.utils import logutils
 
-from astrodata.core import AstroDataError
+from astrodata import AstroDataError
 
 from recipe_system import __version__
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asdf
 astropy>=4.1
 astroquery
 cython


### PR DESCRIPTION
I think this branch is in a good enough state for a merge, as a first step.
~~(And it is waiting for the Gwcs branch with which I will need to fix some conflicts.)~~

What is done here:
- essentially merging `DataProvider`, `FitsProvider` and `FitsProviderProxy` in the `AstroData` class. (Better to have a look directly at `astrodata/core.py` given the number of changes).
- split the reading and writing of FITS files to dedicated functions in the `fits` module, but those are still used directly for `astrodata.open` and `ad.write`. 
- no breaking change!

What remains to be done:
- removing `AstroDataFits`. Currently this is an empty class since it is inherit by other classes in DRAGONS. This is just a matter of changing the inherited class, but I will keep that for a following PR to limit the number of changes here.
- I think the main item is how to replace `extver` with something more generic, e.g. a list of indices. Need some thoughts on the best way to do this.
- Find a better solution for associated objects. Currently these are stored directly in `__dict__`, with a special treatment for tables (with `._tables`). I think it would be cleaner with a dedicated dict, e.g. `_other`.
- Replace `AstroDataFitsDeprecationWarning` with `AstroDataDeprecationWarning` ? If `AstroDataFits` is gone, the latter makes more sense.

cc @chris-simpson @jehturner 