### PR TITLE
Speedup myself

### DIFF
--- a/geminidr/__init__.py
+++ b/geminidr/__init__.py
@@ -22,7 +22,7 @@ import warnings
 import weakref
 
 from copy import deepcopy
-from inspect import stack, isclass
+from inspect import isclass, currentframe
 
 from gempy.eti_core.eti import ETISubprocess
 from gempy.library import config
@@ -224,7 +224,7 @@ class PrimitivesBASE:
         self.stacks           = load_cache(stkindfile)
 
         # This lambda will return the name of the current caller.
-        self.myself           = lambda: stack()[1][3]
+        self.myself = lambda: currentframe().f_back.f_code.co_name
 
         warnings.simplefilter('ignore', category=VerifyWarning)
 


### PR DESCRIPTION
`currentframe()` takes ~200ns versus ~4ms for `stack()` :

```
In [17]: from inspect import stack, isclass, currentframe  
    ...:  
    ...: def myself_stack(): 
    ...:     return stack()[1][3] 
    ...:      
    ...: def myself_currentframe(): 
    ...:     return currentframe().f_back.f_code.co_name 
    ...:  
    ...: def call_stack(): 
    ...:     return myself_stack() 
    ...:      
    ...: def call_currentframe(): 
    ...:     return myself_currentframe() 
    ...:                                                                                                 

In [18]: call_stack()                                                                                    
Out[18]: 'call_stack'

In [19]: call_currentframe()                                                                             
Out[19]: 'call_currentframe'

In [20]: %timeit call_stack()                                                                            
4.06 ms ± 22 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [21]: %timeit call_currentframe()                                                                     
256 ns ± 1.65 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```