### PR TITLE
Updated to fallback to RA, DEC header keywords for unusable WCS 

### DIFF
--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -431,6 +431,8 @@ class AstroDataGnirs(AstroDataGemini):
         # if it's messed up
 
         wcs_ra = self.wcs_ra()
+        if wcs_ra is None:
+            return self.phu.get('RA', None)
         try:
             tgt_ra = self.target_ra(offset=True, icrs=True)
         except:  # Return WCS value if we can't get our sanity check
@@ -469,6 +471,8 @@ class AstroDataGnirs(AstroDataGemini):
         # if it's messed up
 
         wcs_dec = self.wcs_dec()
+        if wcs_dec is None:
+            return self.phu.get('DEC', None)
         try:
             tgt_dec = self.target_dec(offset=True, icrs=True)
         except:  # Return WCS value if we can't get our sanity check

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -117,3 +117,25 @@ def test_descriptor_matches_type(ad, descriptor, expected_type):
     value = getattr(ad, descriptor)()
     assert isinstance(value, expected_type) or value is None, \
         "Assertion failed for file: {}".format(ad.filename)
+
+
+@pytest.mark.dragons_remote_data
+@pytest.mark.parametrize("ad", ["N20190101S0102.fits"], indirect=True)
+def test_ra_and_dec_always_returns_float(ad):
+    """
+    Tests that the get the RA/DEC coordinates using descriptors.
+
+    Parameters
+    ----------
+    ad : fixture
+        Custom fixture that downloads and opens the input file.
+    """
+    if isinstance(ad.wcs_ra(), float) or ad.wcs_ra() is None:
+        assert isinstance(ad.ra(), float)
+
+    if isinstance(ad.wcs_dec(), float) or ad.wcs_dec() is None:
+        assert isinstance(ad.dec(), float)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -141,7 +141,7 @@ def test_ra_and_dec_always_returns_float(ad, monkeypatch):
 @pytest.mark.parametrize("ad", ["N20190101S0102.fits"], indirect=True)
 def test_ra_and_dec_wcs_fallback(ad, monkeypatch):
     """
-    Tests that the get the RA/DEC coordinates using descriptors.
+    Tests that the get the RA/DEC coordinates using descriptors when the WCS coordinate mapping fails
 
     Parameters
     ----------

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -22,6 +22,20 @@ GNIRS_DESCRIPTORS_TYPES = [
 
 @pytest.fixture(params=test_files)
 def ad(request):
+    """
+    Fixture that will download a file from specified as a test parameter,
+    open it as an AstroData object and return it.
+
+    Parameters
+    ----------
+    request : fixture
+        Pytest built-in fixture containing information about the parent test.
+
+    Returns
+    -------
+    AstroData
+        Raw file downloaded from the archive and cached locally.
+    """
     filename = request.param
     path = astrodata.testing.download_from_archive(filename)
     return astrodata.open(path)

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -121,7 +121,7 @@ def test_descriptor_matches_type(ad, descriptor, expected_type):
 
 @pytest.mark.dragons_remote_data
 @pytest.mark.parametrize("ad", ["N20190101S0102.fits"], indirect=True)
-def test_ra_and_dec_always_returns_float(ad):
+def test_ra_and_dec_always_returns_float(ad, monkeypatch):
     """
     Tests that the get the RA/DEC coordinates using descriptors.
 
@@ -135,6 +135,26 @@ def test_ra_and_dec_always_returns_float(ad):
 
     if isinstance(ad.wcs_dec(), float) or ad.wcs_dec() is None:
         assert isinstance(ad.dec(), float)
+
+
+@pytest.mark.dragons_remote_data
+@pytest.mark.parametrize("ad", ["N20190101S0102.fits"], indirect=True)
+def test_ra_and_dec_wcs_fallback(ad, monkeypatch):
+    """
+    Tests that the get the RA/DEC coordinates using descriptors.
+
+    Parameters
+    ----------
+    ad : fixture
+        Custom fixture that downloads and opens the input file.
+    """
+    def _fake_wcs_call():
+        return None
+
+    monkeypatch.setattr(ad, 'wcs_ra', _fake_wcs_call)
+    monkeypatch.setattr(ad, 'wcs_dec', _fake_wcs_call)
+    assert(ad.ra() == ad.phu.get('RA', None))
+    assert(ad.dec() == ad.phu.get('DEC', None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is the same logic currently seen in the core Gemini support, just applying it to GNIRS' custom AstroData logic for ra/dec