### PR TITLE
GNIRS had a change at some point that lower cases the slit value, broke IFU

### DIFF
--- a/astrodata/_version.py
+++ b/astrodata/_version.py
@@ -5,10 +5,10 @@ and to be used in the documentation.
 """
 
 # --- Setup Version Here ---
-API = 2
-FEATURE = 1
-BUG = 1
-TAG = ''
+API = 3
+FEATURE = 0
+BUG = 0
+TAG = 'dev'
 
 
 def version(short=False, tag=TAG):

--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -355,7 +355,7 @@ def get_active_git_branch():
             ['git', 'log', '-n', '1', '--pretty=%d', 'HEAD']
         ).decode('utf8')
         branch_name = re.search(r'\(HEAD.*, origin\/(.*)\)', out).groups()[0]
-    except AttributeError:
+    except subprocess.CalledProcessError as e:
         print("\nCould not retrieve active git branch. Make sure that the\n"
               "following path is a valid Git repository: {}\n"
               .format(os.getcwd()))

--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -3,7 +3,9 @@ Fixtures to be used in tests in DRAGONS
 """
 
 import os
+import re
 import shutil
+import subprocess
 import urllib
 import xml.etree.ElementTree as et
 from contextlib import contextmanager
@@ -152,8 +154,8 @@ def compare_models(model1, model2, rtol=1e-7, atol=0., check_inverse=True):
     models involving orthonormal polynomials etc.
     """
 
-    from numpy.testing import assert_allclose
     from astropy.modeling import Model
+    from numpy.testing import assert_allclose
 
     if not (isinstance(model1, Model) and isinstance(model2, Model)):
         raise TypeError('Inputs must be Model instances')
@@ -229,25 +231,26 @@ def change_working_dir(path_to_outputs):
     """
     path = os.path.join(path_to_outputs, "outputs")
     os.makedirs(path, exist_ok=True)
+    print(f"Using working dir:\n  {path}")
 
     @contextmanager
     def _change_working_dir(sub_path=""):
         """
-        Changed the current working directory temporarily easily using the 
+        Changed the current working directory temporarily easily using the
         `with` statement.
-         
+
         Parameters
         ----------
-        sub_path : str 
+        sub_path : str
             Sub-path inside the directory where we are working.
         """
         oldpwd = os.getcwd()
         os.chdir(path)
-        
+
         if sub_path:
             os.makedirs(sub_path, exist_ok=True)
             os.chdir(sub_path)
-                        
+
         try:
             yield
         finally:
@@ -333,6 +336,34 @@ def get_associated_calibrations(filename, nbias=5):
     return cals
 
 
+def get_active_git_branch():
+    """
+    Returns the name of the active GIT branch to be used in Continuous
+    Integration tasks and organize input/reference files.
+
+    Note: This works currently only if the remote name is "origin", though it
+    would be easy to adapt for other cases if needed.
+
+    Returns
+    -------
+    str or None : Name of the input active git branch. It returns None if
+        the branch name could not be retrieved.
+
+    """
+    try:
+        out = subprocess.check_output(
+            ['git', 'log', '-n', '1', '--pretty=%d', 'HEAD']
+        ).decode('utf8')
+        branch_name = re.search(r'\(HEAD.*, origin\/(.*)\)', out).groups()[0]
+    except AttributeError:
+        print("\nCould not retrieve active git branch. Make sure that the\n"
+              "following path is a valid Git repository: {}\n"
+              .format(os.getcwd()))
+    else:
+        print(f"\nRetrieved active branch name:  {branch_name:s}")
+        return branch_name
+
+
 @pytest.fixture(scope='module')
 def path_to_inputs(request, env_var='DRAGONS_TEST'):
     """
@@ -371,6 +402,14 @@ def path_to_inputs(request, env_var='DRAGONS_TEST'):
         pytest.fail('\n  Path to input test data exists but is not accessible: '
                     '\n    {:s}'.format(path))
 
+    branch_name = get_active_git_branch()
+
+    if branch_name:
+        branch_name = branch_name.replace("/", "_")
+        path_with_branch = path.replace("/inputs", f"/inputs_{branch_name}")
+        path = path_with_branch if os.path.exists(path_with_branch) else path
+
+    print(f"Using the following path to the inputs:\n  {path}\n")
     return path
 
 
@@ -412,6 +451,14 @@ def path_to_refs(request, env_var='DRAGONS_TEST'):
         pytest.fail('\n Path to reference test data exists but is not accessible: '
                     '\n    {:s}'.format(path))
 
+    branch_name = get_active_git_branch()
+
+    if branch_name:
+        branch_name = branch_name.replace("/", "_")
+        path_with_branch = path.replace("/refs", f"/refs_{branch_name}")
+        path = path_with_branch if os.path.exists(path_with_branch) else path
+
+    print(f"Using the following path to the refs:\n  {path}\n")
     return path
 
 
@@ -434,11 +481,9 @@ def path_to_outputs(request, tmp_path_factory):
     IOError
         If output path does not exits.
     """
-    path = tmp_path_factory.mktemp(basename="dragons-test-", numbered=True)
-
     module_path = request.module.__name__.split('.')
     module_path = [item for item in module_path if item not in "tests"]
-    path = os.path.join(str(path), *module_path)
+    path = os.path.join(str(tmp_path_factory.getbasetemp()), *module_path)
     os.makedirs(path, exist_ok=True)
 
     return path

--- a/astrodata/tests/test_testing.py
+++ b/astrodata/tests/test_testing.py
@@ -3,13 +3,37 @@ Tests for the `astrodata.testing` module.
 """
 
 import os
-
-import numpy as np
-import pytest
+import subprocess
 
 import astrodata
+import numpy as np
+import pytest
+from astrodata.testing import (assert_same_class, download_from_archive,
+                               get_active_git_branch)
 
-from astrodata.testing import assert_same_class, download_from_archive
+
+def test_get_active_branch_name(capsys, monkeypatch):
+    """
+    Just execute and prints out the active branch name.
+    """
+
+    # With tracking branch
+    monkeypatch.setattr(subprocess, 'check_output',
+                        lambda *a, **k: b'(HEAD -> master, origin/master)')
+    assert get_active_git_branch() == 'master'
+    captured = capsys.readouterr()
+    assert captured.out == '\nRetrieved active branch name:  master\n'
+
+    # Only remote branch
+    monkeypatch.setattr(subprocess, 'check_output',
+                        lambda *a, **k: b'(HEAD, origin/foo)')
+    assert get_active_git_branch() == 'foo'
+
+    # Raise error
+    def mock_check_output(*args, **kwargs):
+        raise subprocess.CalledProcessError
+    monkeypatch.setattr(subprocess, 'check_output', mock_check_output)
+    assert get_active_git_branch() is None
 
 
 def test_change_working_dir(change_working_dir):
@@ -110,3 +134,15 @@ def test_assert_same_class():
 
     with pytest.raises(AssertionError):
         assert_same_class(ad, np.array([1]))
+
+
+@pytest.mark.skip("Test fixtures might require some extra-work")
+def test_path_to_inputs(path_to_inputs):
+    assert isinstance(path_to_inputs, str)
+    assert "astrodata/test_testing/inputs" in path_to_inputs
+
+
+@pytest.mark.skip("Test fixtures might require some extra-work")
+def test_path_to_refs(path_to_refs):
+    assert isinstance(path_to_refs, str)
+    assert "astrodata/test_testing/refs" in path_to_refs

--- a/astrodata/tests/test_testing.py
+++ b/astrodata/tests/test_testing.py
@@ -31,7 +31,7 @@ def test_get_active_branch_name(capsys, monkeypatch):
 
     # Raise error
     def mock_check_output(*args, **kwargs):
-        raise subprocess.CalledProcessError
+        raise subprocess.CalledProcessError(0, 'git')
     monkeypatch.setattr(subprocess, 'check_output', mock_check_output)
     assert get_active_git_branch() is None
 

--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -52,7 +52,7 @@ class AstroDataGnirs(AstroDataGemini):
             slit = self.phu.get('SLIT', '').lower()
             grat = self.phu.get('GRATING', '')
             prism = self.phu.get('PRISM', '')
-            if slit == 'IFU':
+            if slit == 'ifu':
                 tags.add('IFU')
             elif ('arcsec' in slit or 'pin' in slit) and 'mm' in grat:
                 if 'MIR' in prism:

--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -146,11 +146,6 @@ class Stack(PrimitivesBASE):
             params["nlow"] = 0
             params["nhigh"] = 0
 
-        # Perform various checks on inputs
-        for ad in adinputs:
-            if "PREPARED" not in ad.tags:
-                raise OSError("{} must be prepared" .format(ad.filename))
-
         if len({len(ad) for ad in adinputs}) > 1:
             raise OSError("Not all inputs have the same number of extensions")
         if len({ext.nddata.shape for ad in adinputs for ext in ad}) > 1:

--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -203,6 +203,7 @@ class Visualize(PrimitivesBASE):
                             overlay = overlays[0]
                     masks.append(overlay)
                     mask_colors.append(206)
+                    overlay_index += 1
 
                 # Define the display name
                 if tile and extname=='SCI':

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -92,7 +92,6 @@ def test_stacking_without_gain_or_readnoise(adinputs):
     for ad in adinputs:
         ad.phu['INSTRUME'] = 'F2'
     p = F2Image(adinputs)
-    p.prepare()
     assert adinputs[0].gain() == [None]
     assert adinputs[0].read_noise() == [None]
     ad = p.stackFrames(operation='mean', reject_method='none')[0]

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -15,13 +15,25 @@ from geminidr.f2.primitives_f2_image import F2Image
 
 
 @pytest.fixture
-def adinputs():
+def f2_adinputs():
+    phu = fits.PrimaryHDU()
+    phu.header.update(OBSERVAT='Gemini-North', INSTRUME='F2',
+                      ORIGNAME='S20010101S0001.fits')
+    data = np.ones((2, 2))
+    adinputs = []
+    for i in range(2):
+        ad = astrodata.create(phu)
+        ad.append(data + i)
+        adinputs.append(ad)
+    return adinputs
+
+
+@pytest.fixture
+def niri_adinputs():
     phu = fits.PrimaryHDU()
     phu.header.update(OBSERVAT='Gemini-North', INSTRUME='NIRI',
                       ORIGNAME='N20010101S0001.fits')
-
     data = np.ones((2, 2))
-
     adinputs = []
     for i in range(2):
         ad = astrodata.create(phu)
@@ -31,41 +43,41 @@ def adinputs():
 
 
 @pytest.mark.skip("bquint - Investigate this test")
-def test_error_only_one_file(adinputs, caplog):
+def test_error_only_one_file(niri_adinputs, caplog):
     # With only one file
-    p = NIRIImage(adinputs[1:])
+    p = NIRIImage(niri_adinputs[1:])
     p.stackFrames()
     assert caplog.records[2].message == (
         'No stacking will be performed, since at least two input AstroData '
         'objects are required for stackFrames')
 
 
-def test_error_extension_number(adinputs, caplog):
-    p = NIRIImage(adinputs)
+def test_error_extension_number(niri_adinputs, caplog):
+    p = NIRIImage(niri_adinputs)
     p.prepare()
-    adinputs[1].append(np.zeros((2, 2)))
+    niri_adinputs[1].append(np.zeros((2, 2)))
     match = "Not all inputs have the same number of extensions"
     with pytest.raises(IOError, match=match):
         p.stackFrames()
 
 
-def test_error_extension_shape(adinputs, caplog):
-    adinputs[1][0].data = np.zeros((3, 3))
-    p = NIRIImage(adinputs)
+def test_error_extension_shape(niri_adinputs, caplog):
+    niri_adinputs[1][0].data = np.zeros((3, 3))
+    p = NIRIImage(niri_adinputs)
     p.prepare()
     match = "Not all inputs images have the same shape"
     with pytest.raises(IOError, match=match):
         p.stackFrames()
 
 
-def test_stackframes_refcat_propagation(adinputs):
+def test_stackframes_refcat_propagation(niri_adinputs):
     refcat = Table([[1, 2], ['a', 'b']], names=('Id', 'Cat_Id'))
-    for i, ad in enumerate(adinputs):
+    for i, ad in enumerate(niri_adinputs):
         if i > 0:
             refcat['Cat_Id'] = ['b', 'c']
         ad.REFCAT = refcat
 
-    p = NIRIImage(adinputs)
+    p = NIRIImage(niri_adinputs)
     p.prepare()
     adout = p.stackFrames()[0]
 
@@ -75,25 +87,23 @@ def test_stackframes_refcat_propagation(adinputs):
     assert all(adout.REFCAT['Cat_Id'] == ['a', 'b', 'c'])
 
 
-def test_rejmap(adinputs):
+def test_rejmap(niri_adinputs):
     for i in (2, 3, 4):
-        adinputs.append(adinputs[0] + i)
+        niri_adinputs.append(niri_adinputs[0] + i)
 
-    p = NIRIImage(adinputs)
+    p = NIRIImage(niri_adinputs)
     p.prepare()
     adout = p.stackFrames(reject_method='minmax', nlow=1, nhigh=1,
                           save_rejection_map=True)[0]
     assert_array_equal(adout[0].REJMAP, 2)  # rejected 2 values for each pixel
 
 
-def test_stacking_without_gain_or_readnoise(adinputs):
+def test_stacking_without_gain_or_readnoise(f2_adinputs):
     """We use F2 since it doesn't use a LUT to return values for the
     gain() and read_noise() descriptors"""
-    for ad in adinputs:
-        ad.phu['INSTRUME'] = 'F2'
-    p = F2Image(adinputs)
-    assert adinputs[0].gain() == [None]
-    assert adinputs[0].read_noise() == [None]
+    p = F2Image(f2_adinputs)
+    assert f2_adinputs[0].gain() == [None]
+    assert f2_adinputs[0].read_noise() == [None]
     ad = p.stackFrames(operation='mean', reject_method='none')[0]
     assert ad[0].data.mean() == 1.5
     assert ad[0].data.std() == 0

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -30,12 +30,6 @@ def adinputs():
     return adinputs
 
 
-def test_not_prepared(adinputs):
-    p = NIRIImage(adinputs)
-    with pytest.raises(IOError):
-        p.stackFrames()
-
-
 @pytest.mark.skip("bquint - Investigate this test")
 def test_error_only_one_file(adinputs, caplog):
     # With only one file

--- a/geminidr/gmos/primitives_gmos_spect.py
+++ b/geminidr/gmos/primitives_gmos_spect.py
@@ -280,20 +280,31 @@ class GMOSSpect(Spect, GMOS):
                 ygrid, xgrid = np.indices(ext.shape)
                 # TODO: want with_units
                 waves = trans(xgrid, ygrid)[0] * u.nm  # Wavelength always axis 0
+
+                # Tapering required to prevent QE correction from blowing up
+                # at the extremes (remember, this is a ratio, not the actual QE)
+                # We use half-Gaussians to taper
+                taper = np.ones_like(ext.data)
+                taper_locut, taper_losig = 350 * u.nm, 25 * u.nm
+                taper_hicut, taper_hisig = 1200 * u.nm, 200 * u.nm
+                taper[waves < taper_locut] = np.exp(-((waves[waves < taper_locut]
+                                                       - taper_locut) / taper_losig) ** 2)
+                taper[waves > taper_hicut] = np.exp(-((waves[waves > taper_hicut]
+                                                       - taper_hicut) / taper_hisig) ** 2)
                 try:
-                    qe_correction = qeModel(ext)((waves / u.nm).to(u.dimensionless_unscaled).value).astype(np.float32)
+                    qe_correction = (qeModel(ext)((waves / u.nm).to(u.dimensionless_unscaled).value).astype(
+                        np.float32) - 1) * taper + 1
                 except TypeError:  # qeModel() returns None
                     msg = "No QE correction found for {}:{}".format(ad.filename, ext.hdr['EXTVER'])
                     if 'sq' in self.mode:
                         raise ValueError(msg)
                     else:
                         log.warning(msg)
+                        continue
                 log.stdinfo("Mean relative QE of EXTVER {} is {:.5f}".
                              format(ext.hdr['EXTVER'], qe_correction.mean()))
                 if not is_flat:
                     qe_correction = 1. / qe_correction
-                qe_correction[qe_correction < 0] = 0
-                qe_correction[qe_correction > 10] = 0
                 ext.multiply(qe_correction)
 
             for ext, orig_wcs in zip(ad, original_wcs):

--- a/geminidr/gmos/recipes/sq/recipes_ARC_LS_SPECT.py
+++ b/geminidr/gmos/recipes/sq/recipes_ARC_LS_SPECT.py
@@ -3,8 +3,8 @@ Recipes available to data with tags ['GMOS', 'SPECT', 'LS', 'ARC'].
 These are GMOS longslit arc-lamp calibrations.
 Default is "reduce".
 """
-recipe_tags = {'GMOS', 'SPECT', 'LS', 'ARC'}
-
-from ..ql.recipes_ARC_LS_SPECT import makeProcessedArc
-
-_default = makeProcessedArc
+# recipe_tags = {'GMOS', 'SPECT', 'LS', 'ARC'}
+#
+# from ..ql.recipes_ARC_LS_SPECT import makeProcessedArc
+#
+# _default = makeProcessedArc

--- a/geminidr/gmos/recipes/sq/recipes_FLAT_LS_SPECT.py
+++ b/geminidr/gmos/recipes/sq/recipes_FLAT_LS_SPECT.py
@@ -3,22 +3,22 @@ Recipes available to data with tags ['GMOS', 'SPECT', 'LS', 'FLAT'].
 These are GMOS longslit observations.
 Default is "reduce".
 """
-recipe_tags = {'GMOS', 'SPECT', 'LS', 'FLAT'}
-
-from ..ql.recipes_FLAT_LS_SPECT import makeProcessedFlat
-
-_default = makeProcessedFlat
-
-
-def makeProcessedSlitIllum(p):
-    p.prepare()
-    p.addDQ(static_bpm=None)
-    p.addVAR(read_noise=True)
-    p.overscanCorrect()
-    p.biasCorrect()
-    p.ADUToElectrons()
-    p.addVAR(poisson_noise=True)
-    p.stackFrames()
-    p.makeSlitIllum()
-    p.makeIRAFCompatible()
-    p.storeProcessedSlitIllum()
+# recipe_tags = {'GMOS', 'SPECT', 'LS', 'FLAT'}
+#
+# from ..ql.recipes_FLAT_LS_SPECT import makeProcessedFlat
+#
+# _default = makeProcessedFlat
+#
+#
+# def makeProcessedSlitIllum(p):
+#     p.prepare()
+#     p.addDQ(static_bpm=None)
+#     p.addVAR(read_noise=True)
+#     p.overscanCorrect()
+#     p.biasCorrect()
+#     p.ADUToElectrons()
+#     p.addVAR(poisson_noise=True)
+#     p.stackFrames()
+#     p.makeSlitIllum()
+#     p.makeIRAFCompatible()
+#     p.storeProcessedSlitIllum()

--- a/geminidr/gmos/recipes/sq/recipes_LS_SPECT.py
+++ b/geminidr/gmos/recipes/sq/recipes_LS_SPECT.py
@@ -3,8 +3,8 @@ Recipes available to data with tags ['GMOS', 'SPECT', 'LS'].
 These are GMOS longslit observations.
 Default is "reduceScience".
 """
-recipe_tags = {'GMOS', 'SPECT', 'LS'}
-
-from ..ql.recipes_LS_SPECT import reduceScience, reduceStandard
-
-_default = reduceScience
+# recipe_tags = {'GMOS', 'SPECT', 'LS'}
+#
+# from ..ql.recipes_LS_SPECT import reduceScience, reduceStandard
+#
+# _default = reduceScience

--- a/geminidr/gmos/recipes/sq/recipes_SLITILLUM_LS_SPECT.py
+++ b/geminidr/gmos/recipes/sq/recipes_SLITILLUM_LS_SPECT.py
@@ -3,21 +3,21 @@ Recipes available to data with tags ['GMOS', 'SPECT', 'LS', 'SLITILLUM'].
 These are GMOS longslit observations.
 Default is "reduce".
 """
-recipe_tags = {'GMOS', 'SPECT', 'LS', 'SLITILLUM'}
-
-
-def makeProcessedSlitIllum(p):
-    p.prepare()
-    p.addDQ(static_bpm=None)
-    p.addVAR(read_noise=True)
-    p.overscanCorrect()
-    p.biasCorrect()
-    p.ADUToElectrons()
-    p.addVAR(poisson_noise=True)
-    p.stackFrames()
-    p.makeSlitIllum()
-    p.makeIRAFCompatible()
-    p.storeProcessedSlitIllum()
-
-
-_default = makeProcessedSlitIllum
+# recipe_tags = {'GMOS', 'SPECT', 'LS', 'SLITILLUM'}
+#
+#
+# def makeProcessedSlitIllum(p):
+#     p.prepare()
+#     p.addDQ(static_bpm=None)
+#     p.addVAR(read_noise=True)
+#     p.overscanCorrect()
+#     p.biasCorrect()
+#     p.ADUToElectrons()
+#     p.addVAR(poisson_noise=True)
+#     p.stackFrames()
+#     p.makeSlitIllum()
+#     p.makeIRAFCompatible()
+#     p.storeProcessedSlitIllum()
+#
+#
+# _default = makeProcessedSlitIllum

--- a/geminidr/gmos/recipes/sq/recipes_STANDARD_LS_SPECT.py
+++ b/geminidr/gmos/recipes/sq/recipes_STANDARD_LS_SPECT.py
@@ -3,8 +3,8 @@ Recipes available to data with tags ['GMOS', 'SPECT', 'LS'].
 These are GMOS longslit observations.
 Default is "reduceStandard".
 """
-recipe_tags = {'GMOS', 'SPECT', 'LS', 'STANDARD'}
+#recipe_tags = {'GMOS', 'SPECT', 'LS', 'STANDARD'}
 
-from ..ql.recipes_STANDARD_LS_SPECT import reduceScience, reduceStandard
+#from ..ql.recipes_STANDARD_LS_SPECT import reduceScience, reduceStandard
 
-_default = reduceStandard
+#_default = reduceStandard

--- a/gempy/library/astrotools.py
+++ b/gempy/library/astrotools.py
@@ -88,10 +88,12 @@ def divide0(numerator, denominator):
             return 0 if denominator == 0 else numerator / denominator
         else:
             dtype = np.float32 if is_int else numerator.dtype
-            return np.divide(numerator, denominator, out=np.zeros(numerator.shape, dtype=dtype), where=denominator!=0)
+            return np.divide(numerator, denominator, out=np.zeros(numerator.shape, dtype=dtype),
+                             where=abs(denominator) > np.finfo(dtype).tiny)
     else:
         dtype = np.float32 if is_int else denominator.dtype
-        return np.divide(numerator, denominator, out=np.zeros_like(denominator, dtype=dtype), where=denominator!=0)
+        return np.divide(numerator, denominator, out=np.zeros_like(denominator, dtype=dtype),
+                         where=abs(denominator) > np.finfo(dtype).tiny)
 
 def rasextodec(string):
     """

--- a/gempy/utils/tests/test_showrecipes.py
+++ b/gempy/utils/tests/test_showrecipes.py
@@ -142,7 +142,7 @@ def test_showprims_on_gnirs_spect():
 @pytest.mark.dragons_remote_data
 def test_showprims_on_gmos_spect():
     file_location = astrodata.testing.download_from_archive(GMOS_SPECT)
-    answer = showprims(file_location)
+    answer = showprims(file_location, 'ql')
     assert "geminidr.gmos.recipes.ql.recipes_LS_SPECT::reduce" in answer
 
 


### PR DESCRIPTION
The IFU test was against a value of IFU, so when a lowercase was added probably to work around casing issues on the other values we stopped detecting the IFU case and tagging appropriately.