### PR TITLE
trivial bugfix for GNIRS slit tagging

### DIFF
--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -52,7 +52,7 @@ class AstroDataGnirs(AstroDataGemini):
             slit = self.phu.get('SLIT', '').lower()
             grat = self.phu.get('GRATING', '')
             prism = self.phu.get('PRISM', '')
-            if slit == 'IFU':
+            if slit == 'ifu':
                 tags.add('IFU')
             elif ('arcsec' in slit or 'pin' in slit) and 'mm' in grat:
                 if 'MIR' in prism:


### PR DESCRIPTION
At some point the slit field was being lowercased, probably to avoid casing bugs with the other values.  The IFU check was still using lower case so we stopped tagging IFU GNIRS appropriately.