### PR TITLE
Refactor Astrodata associated objects

### DIFF
--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -624,7 +624,7 @@ class AstroData:
 
         """
         exposed = set(self._tables)
-        if self.is_sliced:
+        if self.is_single:
             nd = self.nddata if self.is_single else self.nddata[0]
             exposed |= set(nd.meta['other'])
         return exposed

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -976,9 +976,6 @@ class AstroData:
         return new_nddata
 
     def _append_table(self, new_table, name, header, add_to, reset_ver=True):
-        if name is not None:
-            name = name.upper()
-
         tb = _process_table(new_table, name, header)
         hname = tb.meta['header'].get('EXTNAME')
 
@@ -1060,16 +1057,15 @@ class AstroData:
             # the moment
             raise TypeError("Can't append objects to non-single slices")
 
-        # FIXME: this was used on FitsProviderProxy:
-        # elif name is None:
-        #     raise TypeError("Can't append objects to a slice without an "
-        #                     "extension name")
-
         # NOTE: Most probably, if we want to copy the input argument, we
         #       should do it here...
         if isinstance(ext, fits.PrimaryHDU):
             raise ValueError("Only one Primary HDU allowed. "
                              "Use .phu if you really need to set one")
+
+        if name is not None:
+            # TODO: warn if not uppercase ?
+            name = name.upper()
 
         if self.is_sliced:
             add_to = self.nddata

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -976,8 +976,11 @@ class AstroData:
         return new_nddata
 
     def _append_table(self, new_table, name, header, add_to, reset_ver=True):
+        if name is not None:
+            name = name.upper()
+
         tb = _process_table(new_table, name, header)
-        hname = tb.meta['header'].get('EXTNAME') if name is None else name
+        hname = tb.meta['header'].get('EXTNAME')
 
         def find_next_num(tables):
             table_num = 1

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -915,9 +915,9 @@ class AstroData:
                 else:
                     raise ValueError("Can't append pixel planes to other "
                                      "objects without a name")
-            elif name is DEFAULT_EXTENSION:
-                raise ValueError("Can't attach '{}' arrays to other objects"
-                                 .format(DEFAULT_EXTENSION))
+            elif name == DEFAULT_EXTENSION:
+                raise ValueError(f"Can't attach '{DEFAULT_EXTENSION}' arrays "
+                                 "to other objects")
             elif name == 'DQ':
                 add_to.mask = data
                 ret = data

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -134,20 +134,13 @@ class AstroData:
         """
         for cls in self.__class__.mro():
             with suppress(AttributeError, KeyError):
-                mangled_dict_name = '_{}__keyword_dict'.format(cls.__name__)
-                return getattr(self, mangled_dict_name)[name]
+                # __keyword_dict is a mangled variable
+                return getattr(self, f'_{cls.__name__}__keyword_dict')[name]
         else:
-            raise AttributeError("No match for '{}'".format(name))
+            raise AttributeError(f"No match for '{name}'")
 
     def _process_tags(self):
-        """
-        Determines the tag set for the current instance.
-
-        Returns
-        -------
-        set of str
-
-        """
+        """Return the tag set (as a set of str) for the current instance."""
         results = []
         # Calling inspect.getmembers on `self` would trigger all the
         # properties (tags, phu, hdr, etc.), and that's undesirable. To
@@ -572,18 +565,14 @@ class AstroData:
                 if attribute in otherh:
                     del otherh[attribute]
             else:
-                raise AttributeError(
-                    "{!r} sliced object has no attribute {!r}"
-                    .format(self.__class__.__name__, attribute))
+                raise AttributeError(f"{self.__class__.__name__!r} sliced "
+                                     "object has no attribute {attribute!r}")
         else:
-            # TODO: So far we're only deleting tables by name.
-            #       Figure out what to do with aliases
             if attribute in self._tables:
                 del self._tables[attribute]
             else:
-                raise AttributeError(
-                    "'{}' is not a global table for this instance"
-                    .format(attribute))
+                raise AttributeError(f"'{attribute}' is not a global table "
+                                     "for this instance")
 
     def __contains__(self, attribute):
         """
@@ -886,8 +875,8 @@ class AstroData:
                 name = DEFAULT_EXTENSION
 
             if name in {'DQ', 'VAR'}:
-                raise ValueError("'{}' need to be associated to a '{}' one"
-                                 .format(name, DEFAULT_EXTENSION))
+                raise ValueError(f"'{name}' need to be associated to a "
+                                 f"'{DEFAULT_EXTENSION}' one")
             else:
                 # FIXME: the logic here is broken since name is
                 # always set to somehing above with DEFAULT_EXTENSION
@@ -906,7 +895,7 @@ class AstroData:
             # Attaching to another extension
             if header is not None and name in {'DQ', 'VAR'}:
                 self._logger.warning(
-                    "The header is ignored for '{}' extensions".format(name))
+                    f"The header is ignored for '{name}' extensions")
             if name is None:
                 # FIXME: both should raise the same exception
                 if self.is_sliced:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -103,17 +103,12 @@ class AstroData:
             this works.
 
         """
-        # Force the data provider to load data, if needed.
-        # FIXME: probably no more needed
-        len(self)
-
         obj = self.__class__()
 
         for attr in ('_phu', '_path', '_orig_filename', '_tables'):
             obj.__dict__[attr] = deepcopy(self.__dict__[attr])
 
         obj.__dict__['_all_nddatas'] = [deepcopy(nd) for nd in self._nddata]
-
         return obj
 
     def _keyword_for(self, name):
@@ -516,11 +511,6 @@ class AstroData:
         """
         if attribute in self._tables:
             return self._tables[attribute]
-
-        # Check if it's an aliased object
-        for nd in self._nddata:
-            if nd.meta.get('name') == attribute:
-                return nd
 
         # I we're working with single slices, let's look some things up
         # in the ND object

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -318,8 +318,14 @@ class AstroData:
 
     @property
     def tables(self):
-        """Return the names of the `astropy.table.Table` objects."""
-        return set(self._tables.keys())
+        """Return the names of the `astropy.table.Table` objects associated to
+        the object or its extensions.
+        """
+        keys = set(self._tables)
+        if self.is_single:
+            keys |= set(key for key, obj in self.nddata.meta['other'].items()
+                        if isinstance(obj, Table))
+        return keys
 
     @property
     @returns_list
@@ -614,8 +620,7 @@ class AstroData:
         """
         exposed = set(self._tables)
         if self.is_single:
-            nd = self.nddata if self.is_single else self.nddata[0]
-            exposed |= set(nd.meta['other'])
+            exposed |= set(self.nddata.meta['other'])
         return exposed
 
     def _pixel_info(self):

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -980,12 +980,27 @@ class AstroData:
             return f'TABLE{table_num}'
 
         if add_to is None:
+            # Find table names for all extensions
+            ext_tables = set()
+            for nd in self._nddata:
+                ext_tables |= set(key for key, obj in nd.meta['other'].items()
+                                  if isinstance(obj, Table))
+
             if hname is None:
-                hname = find_next_num(self._tables)
+                hname = find_next_num(set(self._tables) | ext_tables)
+            elif hname in ext_tables:
+                raise ValueError(f"Cannot append table '{hname}' because it "
+                                 "would hide an extension table")
+
             self._tables[hname] = tb
         else:
             if hname is None:
-                hname = find_next_num(add_to.meta['other'])
+                hname = find_next_num(set(self._tables) |
+                                      set(add_to.meta['other']))
+            elif hname in self._tables:
+                raise ValueError(f"Cannot append table '{hname}' because it "
+                                 "would hide a top-level table")
+
             self._add_to_other(add_to, hname, tb, tb.meta['header'])
             add_to.meta['other'][hname] = tb
         return tb

--- a/astrodata/tests/test_core.py
+++ b/astrodata/tests/test_core.py
@@ -191,7 +191,10 @@ def test_write_and_read(tmpdir, capsys):
     ad.append(tbl, name='BOB')
 
     tbl = Table([np.zeros(5) + 2, np.zeros(5) + 3], names=('c', 'd'))
-    ad.append(tbl, name='BOB', add_to=nd)
+    with pytest.raises(ValueError, match="Cannot append table 'BOB'"):
+        ad.append(tbl, name='BOB', add_to=nd)
+
+    ad.append(tbl, name='BOB2', add_to=nd)
 
     ad.append(np.arange(10), name='MYVAL_WITH_A_VERY_LONG_NAME', add_to=nd)
 
@@ -212,7 +215,7 @@ def test_write_and_read(tmpdir, capsys):
         '[ 0]   science                  NDAstroData       (2, 2)         int64',
         '          .variance             ADVarianceUncerta (2, 2)         float64',
         '          .mask                 ndarray           (2, 2)         uint16',
-        '          .BOB                  Table             (5, 2)         n/a',
+        '          .BOB2                 Table             (5, 2)         n/a',
         '          .MYVAL_WITH_A_VERY_LO ndarray           (10,)          int64',
         '',
         'Other Extensions',

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -748,13 +748,13 @@ def test_add_table():
     assert ad[0].tables == {'TABLE1', 'MYTABLE', 'TABLE2'}
     assert ad[0].exposed == {'TABLE1', 'TABLE2', 'MYTABLE', 'OTHERTABLE'}
 
-    assert ad[0].nddata.TABLE1.meta['header']['INSTRUME'] == 'darkimager'
+    assert ad[0].TABLE1.meta['header']['INSTRUME'] == 'darkimager'
     assert (set(ad[0].nddata.meta['other'].keys()) == {
         'TABLE2', 'OTHERTABLE', 'TABLE1'
     })
-    assert_array_equal(ad[0].nddata.TABLE1['col0'], ['aa', 'bb', 'cc'])
-    assert_array_equal(ad[0].nddata.TABLE2['col0'], ['aa', 'bb', 'cc'])
-    assert_array_equal(ad[0].nddata.OTHERTABLE['col0'], ['aa', 'bb', 'cc'])
+    assert_array_equal(ad[0].TABLE1['col0'], ['aa', 'bb', 'cc'])
+    assert_array_equal(ad[0].TABLE2['col0'], ['aa', 'bb', 'cc'])
+    assert_array_equal(ad[0].OTHERTABLE['col0'], ['aa', 'bb', 'cc'])
 
 
 @pytest.mark.dragons_remote_data

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -745,7 +745,7 @@ def test_add_table():
     ad.append(tbl, add_to=ad[0].nddata, name='OTHERTABLE')
 
     assert list(ad[0].OTHERTABLE['col0']) == ['aa', 'bb', 'cc']
-    assert ad[0].tables == {'TABLE1', 'MYTABLE', 'TABLE2'}
+    assert ad[0].tables == {'TABLE1', 'MYTABLE', 'TABLE2', 'OTHERTABLE'}
     assert ad[0].exposed == {'TABLE1', 'TABLE2', 'MYTABLE', 'OTHERTABLE'}
 
     assert ad[0].TABLE1.meta['header']['INSTRUME'] == 'darkimager'

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -745,15 +745,17 @@ def test_add_table():
     ad.append(tbl, add_to=ad[0].nddata, name='OTHERTABLE')
 
     assert list(ad[0].OTHERTABLE['col0']) == ['aa', 'bb', 'cc']
-    assert ad[0].tables == {'TABLE1', 'MYTABLE', 'TABLE2', 'OTHERTABLE'}
-    assert ad[0].exposed == {'TABLE1', 'TABLE2', 'MYTABLE', 'OTHERTABLE'}
 
-    assert ad[0].TABLE1.meta['header']['INSTRUME'] == 'darkimager'
-    assert (set(ad[0].nddata.meta['other'].keys()) == {
-        'TABLE2', 'OTHERTABLE', 'TABLE1'
-    })
-    assert_array_equal(ad[0].TABLE1['col0'], ['aa', 'bb', 'cc'])
-    assert_array_equal(ad[0].TABLE2['col0'], ['aa', 'bb', 'cc'])
+    expected_tables = {'MYTABLE', 'OTHERTABLE', 'TABLE1', 'TABLE2',
+                       'TABLE3', 'TABLE4'}
+    assert ad[0].tables == expected_tables
+    assert ad[0].exposed == expected_tables
+
+    assert ad[0].TABLE3.meta['header']['INSTRUME'] == 'darkimager'
+    assert set(ad[0].nddata.meta['other'].keys()) == {'OTHERTABLE',
+                                                      'TABLE3', 'TABLE4'}
+    assert_array_equal(ad[0].TABLE3['col0'], ['aa', 'bb', 'cc'])
+    assert_array_equal(ad[0].TABLE4['col0'], ['aa', 'bb', 'cc'])
     assert_array_equal(ad[0].OTHERTABLE['col0'], ['aa', 'bb', 'cc'])
 
 

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -91,7 +91,7 @@ def test_append_tables():
     ad.append(nd)
     ad.append(Table([[1]]))
     ad.append(Table([[2]]), add_to=ad[0].nddata)
-    assert ad[0].TABLE1['col0'][0] == 2
+    assert ad[0].TABLE2['col0'][0] == 2
 
 
 def test_append_tables2():

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -109,18 +109,19 @@ def test_append_tables2():
     assert ad[1:].exposed == set()
 
 
-def test_append_tables_lowercase_name():
+def test_append_lowercase_name():
     nd = NDData(np.zeros((4, 5)), meta={'header': {}})
     ad = astrodata.create({})
     ad.append(nd)
     ad.append(Table([[1]]), name='foo')
     ad.append(Table([[1], [2]]), name='bar', add_to=ad[0].nddata)
+    ad.append(np.zeros(3), name='arr', add_to=ad[0].nddata)
 
     assert ad.tables == {'FOO'}
     assert ad.exposed == {'FOO'}
 
     assert ad[0].tables == {'FOO'}
-    assert ad[0].exposed == {'FOO', 'BAR'}
+    assert ad[0].exposed == {'FOO', 'BAR', 'ARR'}
 
 
 @pytest.mark.dragons_remote_data

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -82,6 +82,18 @@ def test_append_image_hdu():
     assert ad[1].data is hdu.data
 
 
+def test_append_tables():
+    """If both ad and ad[0] have a TABLE1, check that ad[0].TABLE1 return the
+    extension table.
+    """
+    nd = NDData(np.zeros((4, 5)), meta={'header': {}})
+    ad = astrodata.create({})
+    ad.append(nd)
+    ad.append(Table([[1]]))
+    ad.append(Table([[2]]), add_to=ad[0].nddata)
+    assert ad[0].TABLE1['col0'][0] == 2
+
+
 @pytest.mark.dragons_remote_data
 def test_can_read_data(testfile1):
     ad = astrodata.open(testfile1)

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -120,7 +120,7 @@ def test_append_lowercase_name():
     assert ad.tables == {'FOO'}
     assert ad.exposed == {'FOO'}
 
-    assert ad[0].tables == {'FOO'}
+    assert ad[0].tables == {'FOO', 'BAR'}
     assert ad[0].exposed == {'FOO', 'BAR', 'ARR'}
 
 

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -109,6 +109,20 @@ def test_append_tables2():
     assert ad[1:].exposed == set()
 
 
+def test_append_tables_lowercase_name():
+    nd = NDData(np.zeros((4, 5)), meta={'header': {}})
+    ad = astrodata.create({})
+    ad.append(nd)
+    ad.append(Table([[1]]), name='foo')
+    ad.append(Table([[1], [2]]), name='bar', add_to=ad[0].nddata)
+
+    assert ad.tables == {'FOO'}
+    assert ad.exposed == {'FOO'}
+
+    assert ad[0].tables == {'FOO'}
+    assert ad[0].exposed == {'FOO', 'BAR'}
+
+
 @pytest.mark.dragons_remote_data
 def test_can_read_data(testfile1):
     ad = astrodata.open(testfile1)

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -94,6 +94,21 @@ def test_append_tables():
     assert ad[0].TABLE1['col0'][0] == 2
 
 
+def test_append_tables2():
+    """Check that slices do not report extension tables."""
+    ad = astrodata.create({})
+    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
+    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
+    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
+    ad.append(Table([[1]]), name='TABLE1', add_to=ad[0].nddata)
+    ad.append(Table([[1]]), name='TABLE2', add_to=ad[1].nddata)
+    ad.append(Table([[1]]), name='TABLE3', add_to=ad[2].nddata)
+
+    assert ad.exposed == set()
+    assert ad[1].exposed == {'TABLE2'}
+    assert ad[1:].exposed == set()
+
+
 @pytest.mark.dragons_remote_data
 def test_can_read_data(testfile1):
     ad = astrodata.open(testfile1)


### PR DESCRIPTION
- Remove `_exposed`
- Tables are no more stored in `__dict__`
- `ext.tables` also returns the extension tables
- Force associated object names to be uppercase
- Prevent conflicts with table names, between the top-level object and its extensions.