### PR TITLE
Restrict .append to append new extensions

### DIFF
--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -878,13 +878,6 @@ class AstroData:
 
         if add_to is None:
             # Top level extension
-
-            # Special cases for Gemini
-            if name is None:
-                name = DEFAULT_EXTENSION
-
-            # FIXME: the logic here is broken since name is
-            # always set to somehing above with DEFAULT_EXTENSION
             if name is not None:
                 hname = name
             elif header is not None:
@@ -897,15 +890,7 @@ class AstroData:
             ret = self._append_imagehdu(hdu, name=hname, header=None,
                                         add_to=None)
         else:
-            if name is None:
-                # FIXME: both should raise the same exception
-                if self.is_sliced:
-                    raise TypeError("Can't append objects to a slice "
-                                    "without an extension name")
-                else:
-                    raise ValueError("Can't append pixel planes to other "
-                                     "objects without a name")
-            elif name == DEFAULT_EXTENSION:
+            if name == DEFAULT_EXTENSION:
                 raise ValueError(f"Can't attach '{DEFAULT_EXTENSION}' arrays "
                                  "to other objects")
             else:
@@ -982,10 +967,7 @@ class AstroData:
 
             self._tables[hname] = tb
         else:
-            if hname is None:
-                hname = find_next_num(set(self._tables) |
-                                      set(add_to.meta['other']))
-            elif hname in self._tables:
+            if hname in self._tables:
                 raise ValueError(f"Cannot append table '{hname}' because it "
                                  "would hide a top-level table")
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -544,11 +544,17 @@ class AstroData:
             # the NDData objects. First we check if the attribute belongs to
             # this object's dictionary.  Otherwise, see if we can pass it down.
             #
-            # CJS 20200131: if the attribute is "exposed" then we should set
-            # it via the append method I think (it's a Table or something)
             if self.is_sliced and not self.is_single:
                 raise TypeError("This attribute can only be "
                                 "assigned to a single-slice object")
+
+            if attribute == DEFAULT_EXTENSION:
+                raise AttributeError(f"{attribute} extensions should be "
+                                     "appended with .append")
+            elif attribute in {'DQ', 'VAR'}:
+                raise AttributeError(f"{attribute} should be set on the "
+                                     "nddata object")
+
             add_to = self.nddata if self.is_single else None
             self._append(value, name=attribute, add_to=add_to)
             return
@@ -888,12 +894,8 @@ class AstroData:
             ret = self._append_imagehdu(hdu, name=hname, header=None,
                                         add_to=None)
         else:
-            if name == DEFAULT_EXTENSION:
-                raise ValueError(f"Can't attach '{DEFAULT_EXTENSION}' arrays "
-                                 "to other objects")
-            else:
-                self._add_to_other(add_to, name, data, header=header)
-                ret = data
+            self._add_to_other(add_to, name, data, header=header)
+            ret = data
 
         return ret
 

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import textwrap
+import warnings
 from collections import OrderedDict
 from contextlib import suppress
 from copy import deepcopy
@@ -1060,8 +1061,9 @@ class AstroData:
             raise ValueError("Only one Primary HDU allowed. "
                              "Use .phu if you really need to set one")
 
-        if name is not None:
-            # TODO: warn if not uppercase ?
+        if name is not None and not name.isupper():
+            warnings.warn(f"extension name '{name}' should be uppercase",
+                          UserWarning)
             name = name.upper()
 
         return self._append(ext, name=name, header=header, reset_ver=reset_ver)

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -832,26 +832,24 @@ class AstroData:
 
     def _process_pixel_plane(self, pixim, name=None, top_level=False,
                              reset_ver=True, custom_header=None):
-        if not isinstance(pixim, NDDataObject):
-            # Assume that we get an ImageHDU or something that can be
-            # turned into one
-            if isinstance(pixim, fits.ImageHDU):
-                nd = NDDataObject(pixim.data, meta={'header': pixim.header})
-            elif custom_header is not None:
-                nd = NDDataObject(pixim, meta={'header': custom_header})
-            else:
-                nd = NDDataObject(pixim, meta={'header': {}})
-        else:
+        # Assume that we get an ImageHDU or something that can be
+        # turned into one
+        if isinstance(pixim, fits.ImageHDU):
+            nd = NDDataObject(pixim.data, meta={'header': pixim.header})
+        elif isinstance(pixim, NDDataObject):
             nd = pixim
-            if custom_header is not None:
-                nd.meta['header'] = custom_header
+        else:
+            nd = NDDataObject(pixim)
 
-        header = nd.meta['header']
+        if custom_header is not None:
+            nd.meta['header'] = custom_header
+
+        header = nd.meta.setdefault('header', {})
         currname = header.get('EXTNAME')
         ver = header.get('EXTVER', -1)
 
         # TODO: Review the logic. This one seems bogus
-        if name and (currname is None):
+        if name and currname is None:
             header['EXTNAME'] = name if name is not None else DEFAULT_EXTENSION
 
         if top_level:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -1057,6 +1057,9 @@ class AstroData:
         if isinstance(ext, fits.PrimaryHDU):
             raise ValueError("Only one Primary HDU allowed. "
                              "Use .phu if you really need to set one")
+        elif isinstance(ext, Table):
+            raise ValueError("Tables should be set directly as attribute, "
+                             "i.e. 'ad.MYTABLE = table'")
 
         if name is not None and not name.isupper():
             warnings.warn(f"extension name '{name}' should be uppercase",

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -848,8 +848,7 @@ class AstroData:
         currname = header.get('EXTNAME')
         ver = header.get('EXTVER', -1)
 
-        # TODO: Review the logic. This one seems bogus
-        if name and currname is None:
+        if currname is None:
             header['EXTNAME'] = name if name is not None else DEFAULT_EXTENSION
 
         if top_level:

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -992,6 +992,12 @@ class AstroData:
 
     def _append(self, ext, name=None, header=None, reset_ver=True,
                 add_to=None):
+        """
+        Internal method to dispatch to the type specific methods. This is
+        called either by ``.append`` to append on top-level objects only or
+        by ``__setattr__``. In the second case ``name`` cannot be None, so
+        this is always the case when appending to extensions (add_to != None).
+        """
         dispatcher = (
             (NDData, self._append_raw_nddata),
             ((Table, fits.TableHDU, fits.BinTableHDU), self._append_table),

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -505,40 +505,42 @@ def read_fits(cls, source, extname_parser=None):
             else:
                 parts['other'].append(extra_unit)
 
-        if hdulist._file is not None and hdulist._file.memmap:
-            # Create the NDData object, using FitsLazyLoadable to delay
-            # loading of the data
-            nd = NDDataObject(
-                    data=FitsLazyLoadable(parts['data']),
-                    uncertainty=(None if parts['uncertainty'] is None
-                                 else FitsLazyLoadable(parts['uncertainty'])),
-                    mask=(None if parts['mask'] is None
-                          else FitsLazyLoadable(parts['mask'])),
-                    wcs=(None if parts['wcs'] is None
-                         else asdftablehdu_to_wcs(parts['wcs'])),
-                    )
-            if nd.wcs is None:
-                nd.wcs = adwcs.fitswcs_to_gwcs(nd.meta['header'])
-                # In case WCS info is in the PHU
-                if nd.wcs is None:
-                    nd.wcs = adwcs.fitswcs_to_gwcs(hdulist[0].header)
-            ad.append(nd, name=DEFAULT_EXTENSION, reset_ver=False)
-        else:
-            nd = ad.append(parts['data'], name=DEFAULT_EXTENSION,
-                           reset_ver=False)
-            for item_name in ('mask', 'uncertainty'):
-                item = parts[item_name]
-                if item is not None:
-                    ad.append(item, name=item.header['EXTNAME'], add_to=nd)
+        header = parts['data'].header
+        lazy = hdulist._file is not None and hdulist._file.memmap
 
-            if isinstance(nd, NDData):
-                if parts['wcs'] is not None:
-                    nd.wcs = asdftablehdu_to_wcs(parts['wcs'])
+        for part_name in ('data', 'mask', 'uncertainty'):
+            if parts[part_name] is not None:
+                if lazy:
+                    # Use FitsLazyLoadable to delay loading of the data
+                    parts[part_name] = FitsLazyLoadable(parts[part_name])
                 else:
-                    try:
-                        nd.wcs = adwcs.fitswcs_to_gwcs(nd.meta['header'])
-                    except TypeError:
-                        pass
+                    # Otherwise use the data array
+                    parts[part_name] = parts[part_name].data
+
+        # handle the variance if not lazy
+        if (parts['uncertainty'] is not None and
+                not isinstance(parts['uncertainty'], FitsLazyLoadable)):
+            parts['uncertainty'] = ADVarianceUncertainty(parts['uncertainty'])
+
+        # Create the NDData object
+        nd = NDDataObject(
+            data=parts['data'],
+            uncertainty=parts['uncertainty'],
+            mask=parts['mask'],
+            meta={'header': header},
+        )
+
+        if parts['wcs'] is not None:
+            # Load the gWCS object from the ASDF extension
+            nd.wcs = asdftablehdu_to_wcs(parts['wcs'])
+        if nd.wcs is None:
+            # Fallback to the data header
+            nd.wcs = adwcs.fitswcs_to_gwcs(nd.meta['header'])
+            if nd.wcs is None:
+                # In case WCS info is in the PHU
+                nd.wcs = adwcs.fitswcs_to_gwcs(hdulist[0].header)
+
+        ad.append(nd, name=DEFAULT_EXTENSION, reset_ver=False)
 
         for other in parts['other']:
             # FIXME: handle case where EXTNAME is missing or None

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -541,7 +541,8 @@ def read_fits(cls, source, extname_parser=None):
                         pass
 
         for other in parts['other']:
-            ad.append(other, name=other.header['EXTNAME'], add_to=nd)
+            # FIXME: handle case where EXTNAME is missing or None
+            setattr(ad[-1], other.header['EXTNAME'], other)
 
     for other in hdulist:
         if other in seen:

--- a/astrodata/provenance.py
+++ b/astrodata/provenance.py
@@ -100,11 +100,11 @@ def add_provenance_history(ad, timestamp_start, timestamp_stop, primitive, args)
     primitive_arr.append(primitive)
     args_arr.append(args)
 
-    dtype = ("S28", "S28", "S128", "S%d" % colsize)
-    ad.append(Table(
+    ad.PROVENANCE_HISTORY = Table(
         [timestamp_start_arr, timestamp_stop_arr, primitive_arr, args_arr],
         names=('timestamp_start', 'timestamp_stop', 'primitive', 'args'),
-        dtype=dtype), name="PROVENANCE_HISTORY")
+        dtype=("S28", "S28", "S128", "S%d" % colsize)
+    )
 
 
 def clone_provenance(provenance_data, ad):

--- a/astrodata/tests/test_core.py
+++ b/astrodata/tests/test_core.py
@@ -188,7 +188,12 @@ def test_write_and_read(tmpdir, capsys):
     ad.append(nd)
 
     tbl = Table([np.zeros(10), np.ones(10)], names=('a', 'b'))
-    ad.append(tbl, name='BOB')
+
+    with pytest.raises(ValueError,
+                       match='Tables should be set directly as attribute'):
+        ad.append(tbl, name='BOB')
+
+    ad.BOB = tbl
 
     tbl = Table([np.zeros(5) + 2, np.zeros(5) + 3], names=('c', 'd'))
 

--- a/astrodata/tests/test_core.py
+++ b/astrodata/tests/test_core.py
@@ -191,17 +191,17 @@ def test_write_and_read(tmpdir, capsys):
     ad.append(tbl, name='BOB')
 
     tbl = Table([np.zeros(5) + 2, np.zeros(5) + 3], names=('c', 'd'))
-    with pytest.raises(ValueError, match="Cannot append table 'BOB'"):
-        ad.append(tbl, name='BOB', add_to=nd)
 
-    ad.append(tbl, name='BOB2', add_to=nd)
+    match = "Cannot append table 'BOB' because it would hide a top-level table"
+    with pytest.raises(ValueError, match=match):
+        ad[0].BOB = tbl
 
-    ad.append(np.arange(10), name='MYVAL_WITH_A_VERY_LONG_NAME', add_to=nd)
+    ad[0].BOB2 = tbl
+    ad[0].MYVAL_WITH_A_VERY_LONG_NAME = np.arange(10)
 
     match = "You can only append NDData derived instances at the top level"
     with pytest.raises(TypeError, match=match):
-        ad.append(NDData(data=np.ones(10), meta={'header': fits.Header()}),
-                  name='MYNDD', add_to=nd)
+        ad[0].MYNDD = NDData(data=np.ones(10), meta={'header': fits.Header()})
 
     testfile = str(tmpdir.join('testfile.fits'))
     ad.write(testfile)

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -467,7 +467,12 @@ def test_can_append_table_and_access_data(capsys, tmpdir):
     phu = fits.PrimaryHDU()
     ad = astrodata.create(phu)
     astrodata.add_header_to_table(tbl)
-    ad.append(tbl, name='BOB')
+
+    with pytest.raises(ValueError,
+                       match='Tables should be set directly as attribute'):
+        ad.append(tbl, name='BOB')
+
+    ad.BOB = tbl
     assert ad.exposed == {'BOB'}
 
     assert ad.tables == {'BOB'}
@@ -760,13 +765,13 @@ def test_add_table():
     ad.append(fakedata)
 
     tbl = Table([['a', 'b', 'c'], [1, 2, 3]])
-    ad.append(tbl)
+    ad.TABLE1 = tbl
     assert ad.tables == {'TABLE1'}
 
-    ad.append(tbl)
+    ad.TABLE2 = tbl
     assert ad.tables == {'TABLE1', 'TABLE2'}
 
-    ad.append(tbl, name='MYTABLE')
+    ad.MYTABLE = tbl
     assert ad.tables == {'TABLE1', 'TABLE2', 'MYTABLE'}
 
     tbl = Table([['aa', 'bb', 'cc'], [1, 2, 3]])
@@ -791,8 +796,7 @@ def test_add_table():
 @pytest.mark.dragons_remote_data
 def test_copy(GSAOI_DARK, capsys):
     ad = astrodata.open(GSAOI_DARK)
-    tbl = Table([['a', 'b', 'c'], [1, 2, 3]])
-    ad.append(tbl)
+    ad.TABLE = Table([['a', 'b', 'c'], [1, 2, 3]])
     ad[0].MYTABLE = Table([['aa', 'bb', 'cc'], [1, 2, 3]])
 
     ad.info()

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -752,8 +752,8 @@ def test_add_var_and_dq():
                        match="'VAR' need to be associated to a 'SCI' one"):
         ad.append(np.ones(shape), name='VAR')
 
-    with pytest.raises(ValueError,
-                       match="Can't attach 'SCI' arrays to other objects"):
+    with pytest.raises(AttributeError,
+                       match="SCI extensions should be appended with .append"):
         ad[0].SCI = np.ones(shape)
 
 

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -450,8 +450,7 @@ def test_can_make_and_write_ad_object(tmpdir):
 
     hdr = fits.Header({'EXTNAME': 'SCI', 'EXTVER': 1, 'FOO': 'BAR'})
     ad.append(hdu, header=hdr)
-    # FIXME: custom header is ignored
-    # assert ad[1].hdr['FOO'] == 'BAR'
+    assert ad[1].hdr['FOO'] == 'BAR'
 
     # Write file and test it exists properly
     testfile = str(tmpdir.join('created_fits_file.fits'))

--- a/astrodata/tests/test_fits.py
+++ b/astrodata/tests/test_fits.py
@@ -396,6 +396,26 @@ def test_from_hdulist(NIFS_DARK):
         assert ad.path == 'N20160727S0077.fits'
 
 
+def test_from_hdulist2():
+    tablehdu = fits.table_to_hdu(Table([[1]]))
+    tablehdu.name = 'REFCAT'
+
+    hdul = fits.HDUList([
+        fits.PrimaryHDU(header=fits.Header({'INSTRUME': 'FISH'})),
+        fits.ImageHDU(data=np.zeros(10), name='SCI', ver=1),
+        fits.ImageHDU(data=np.ones(10), name='VAR', ver=1),
+        fits.ImageHDU(data=np.zeros(10, dtype='uint16'), name='DQ', ver=1),
+        tablehdu,
+    ])
+
+    ad = astrodata.open(hdul)
+    assert len(ad) == 1
+    assert_array_equal(ad[0].data, 0)
+    assert_array_equal(ad[0].variance, 1)
+    assert_array_equal(ad[0].mask, 0)
+    assert len(ad.REFCAT) == 1
+
+
 def test_can_make_and_write_ad_object(tmpdir):
     # Creates data and ad object
     phu = fits.PrimaryHDU()

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -303,6 +303,10 @@ def test_append_single_slice(testfile1, testfile2):
     assert np.all(ad2[-1].data == ad[1].data)
     assert last_ever < ad2[-1].nddata.meta['header'].get('EXTVER', -1)
 
+    # With a custom header
+    ad2.append(ad[1], header=fits.Header({'FOO': 'BAR'}))
+    assert ad2[-1].nddata.meta['header']['FOO'] == 'BAR'
+
 
 @pytest.mark.dragons_remote_data
 def test_append_non_single_slice(testfile1, testfile2):
@@ -329,6 +333,10 @@ def test_append_slice_to_extension(testfile1, testfile2):
 
     with pytest.raises(TypeError):
         ad2[0].append(ad[0], name="FOOBAR")
+
+    match = "Cannot append an AstroData slice to another slice"
+    with pytest.raises(ValueError, match=match):
+        ad[2].FOO = ad2[1]
 
 
 @pytest.mark.dragons_remote_data

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -87,18 +87,9 @@ def test_append_image_hdu():
 
 def test_append_lowercase_name():
     ad = astrodata.create({})
-    ad.append(NDData(np.zeros((4, 5))))
     with pytest.warns(UserWarning,
-                      match="extension name '.*' should be uppercase"):
-        ad.append(Table([[1]]), name='foo')
-    ad[0].BAR = Table([[1], [2]])
-    ad[0].ARR = np.zeros(3)
-
-    assert ad.tables == {'FOO'}
-    assert ad.exposed == {'FOO'}
-
-    assert ad[0].tables == {'FOO', 'BAR'}
-    assert ad[0].exposed == {'FOO', 'BAR', 'ARR'}
+                      match="extension name 'sci' should be uppercase"):
+        ad.append(NDData(np.zeros((4, 5))), name='sci')
 
 
 def test_append_arrays(tmp_path):
@@ -229,20 +220,6 @@ def test_append_nddata_to_root_with_arbitrary_name(testfile2):
         ad.append(nd)
 
 
-def test_append_table():
-    ad = astrodata.create({})
-
-    # With name
-    table = Table(([1, 2, 3], [4, 5, 6], [7, 8, 9]), names=('a', 'b', 'c'))
-    ad.append(table, 'MYTABLE')
-    assert (ad.MYTABLE == table).all()
-
-    # Without name
-    table = Table(([1, 2, 3], [4, 5, 6], [7, 8, 9]), names=('a', 'b', 'c'))
-    ad.append(table)
-    assert isinstance(ad.TABLE1, Table)
-
-
 def test_append_table_to_extensions():
     ad = astrodata.create({})
     ad.append(NDData(np.zeros((4, 5))))
@@ -263,7 +240,7 @@ def test_append_table_to_extensions():
     match = ("Cannot append table 'TABLE1' because it would hide an "
              "extension table")
     with pytest.raises(ValueError, match=match):
-        ad.append(Table([[1]]), name='TABLE1')
+        ad.TABLE1 = Table([[1]])
 
 
 # Append / assign Gemini specific

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -86,9 +86,8 @@ def test_append_image_hdu():
 
 
 def test_append_lowercase_name():
-    nd = NDData(np.zeros((4, 5)), meta={'header': {}})
     ad = astrodata.create({})
-    ad.append(nd)
+    ad.append(NDData(np.zeros((4, 5))))
     with pytest.warns(UserWarning,
                       match="extension name '.*' should be uppercase"):
         ad.append(Table([[1]]), name='foo')
@@ -246,9 +245,9 @@ def test_append_table():
 
 def test_append_table_to_extensions():
     ad = astrodata.create({})
-    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
-    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
-    ad.append(NDData(np.zeros((4, 5)), meta={'header': {}}))
+    ad.append(NDData(np.zeros((4, 5))))
+    ad.append(NDData(np.zeros((4, 5))))
+    ad.append(NDData(np.zeros((4, 5))))
     ad[0].TABLE1 = Table([[1]])
     ad[0].TABLE2 = Table([[22]])
     ad[1].TABLE2 = Table([[2]])  # extensions can have the same table name

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -99,6 +99,13 @@ def test_append_arrays(tmp_path):
     ad.append(np.zeros(10))
     ad[0].ARR = np.arange(5)
 
+    with pytest.raises(AttributeError):
+        ad[0].SCI = np.arange(5)
+    with pytest.raises(AttributeError):
+        ad[0].VAR = np.arange(5)
+    with pytest.raises(AttributeError):
+        ad[0].DQ = np.arange(5)
+
     match = ("Arbitrary image extensions can only be added in association "
              "to a 'SCI'")
     with pytest.raises(ValueError, match=match):
@@ -251,18 +258,18 @@ def test_append_dq_var(testfile2):
 
     dq = np.zeros(ad[0].data.shape)
     with pytest.raises(ValueError):
-        ad.append(dq, 'DQ')
-    with pytest.raises(ValueError):
+        ad.append(dq, name='DQ')
+    with pytest.raises(AttributeError):
         ad.DQ = dq
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         ad[0].DQ = dq
 
     var = np.ones(ad[0].data.shape)
     with pytest.raises(ValueError):
-        ad.append(var, 'VAR')
-    with pytest.raises(ValueError):
+        ad.append(var, name='VAR')
+    with pytest.raises(AttributeError):
         ad.VAR = var
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         ad[0].VAR = var
 
 

--- a/astrodata/tests/test_object_construction.py
+++ b/astrodata/tests/test_object_construction.py
@@ -89,7 +89,9 @@ def test_append_lowercase_name():
     nd = NDData(np.zeros((4, 5)), meta={'header': {}})
     ad = astrodata.create({})
     ad.append(nd)
-    ad.append(Table([[1]]), name='foo')
+    with pytest.warns(UserWarning,
+                      match="extension name '.*' should be uppercase"):
+        ad.append(Table([[1]]), name='foo')
     ad[0].BAR = Table([[1], [2]])
     ad[0].ARR = np.zeros(3)
 

--- a/astrodata/tests/test_tags.py
+++ b/astrodata/tests/test_tags.py
@@ -88,7 +88,7 @@ def testfile(tmpdir):
     ad = astrodata.create(phu, [hdu, hdu2])
     tbl = Table([np.zeros(10), np.ones(10)], names=['col1', 'col2'])
     astrodata.add_header_to_table(tbl)
-    ad.append(tbl, name='MYCAT')
+    ad.MYCAT = tbl
     filename = str(tmpdir.join('fakebias.fits'))
     ad.write(filename)
     yield filename


### PR DESCRIPTION
Adding tables and associated arrays must now be done by setting them to the AstroData object, e.g. `ad.TABLE = Table(...)` or `ad[0].ARRAY = np.array(...)`, to avoid having multiple syntax to do that. This simplifies various things in the append logic, as the attribute name is no more optional and must be an uppercase name. 