### PR TITLE
Remove padding from GMOSLongslit.normalizeFlat()

### DIFF
--- a/geminidr/gemini/lookups/timestamp_keywords.py
+++ b/geminidr/gemini/lookups/timestamp_keywords.py
@@ -9,6 +9,7 @@ timestamp_keys = {
     "addIllumMaskToDQ": "ADILLMSK",
     "addMDF": "ADDMDF",
     "addObjectMaskToDQ": "ADOBJMSK",
+    "addPaddingToDQ":  "ADPAD2DQ",
     "addReferenceCatalog": "ADDRECAT",
     "addVAR": "ADDVAR",
     "adjustWCSToReference": "CORRWCS",

--- a/geminidr/gmos/parameters_gmos.py
+++ b/geminidr/gmos/parameters_gmos.py
@@ -4,18 +4,28 @@ from gempy.library import config
 from geminidr.core import parameters_visualize, parameters_ccd
 from geminidr.gemini import parameters_qa
 
+
+class addPaddingToDQConfig(config.Config):
+    pad_size = config.Field("Padding size for Hamamatsu detectors",
+                            dtype=int, default=21, optional=True)
+
+
 class displayConfig(parameters_visualize.displayConfig):
     remove_bias = config.Field("Remove estimated bias level before displaying?", bool, True)
+
 
 class measureBGConfig(parameters_qa.measureBGConfig):
     remove_bias = config.Field("Remove estimated bias level?", bool, True)
 
+
 class measureIQConfig(parameters_qa.measureIQConfig):
     remove_bias = config.Field("Remove estimated bias level before displaying?", bool, True)
+
 
 class subtractOverscanConfig(parameters_ccd.subtractOverscanConfig):
     nbiascontam = config.RangeField("Number of columns to exclude from averaging",
                                int, None, min=0, optional=True)
+
     def setDefaults(self):
         self.function = None
 
@@ -23,6 +33,7 @@ class subtractOverscanConfig(parameters_ccd.subtractOverscanConfig):
         config.Config.validate(self)
         if self.function == "spline" and self.order == 0:
             raise ValueError("Must specify a positive spline order, or None")
+
 
 # We need to redefine this to ensure it inherits this version of
 # subtractOverscanConfig.validate()

--- a/geminidr/gmos/primitives_gmos_longslit.py
+++ b/geminidr/gmos/primitives_gmos_longslit.py
@@ -623,10 +623,6 @@ class GMOSLongslit(GMOSSpect, GMOSNodAndShuffle):
                     ext.mask ^= (np.bitwise_and.reduce(ext.mask, axis=1) & DQ.unilluminated)[:, None]
                 except TypeError:  # ext.mask is None
                     pass
-                else:
-                    if is_hamamatsu:
-                        ext.mask[:, :21 // xbin] = 1
-                        ext.mask[:, -21 // xbin:] = 1
 
                 masked_data = np.ma.masked_array(ext.data, mask=ext.mask)
                 weights = np.sqrt(at.divide0(1., ext.variance))

--- a/geminidr/gmos/primitives_gmos_longslit.py
+++ b/geminidr/gmos/primitives_gmos_longslit.py
@@ -612,7 +612,6 @@ class GMOSLongslit(GMOSSpect, GMOSNodAndShuffle):
         for ad in adinputs:
             xbin, ybin = ad.detector_x_bin(), ad.detector_y_bin()
             array_info = gt.array_information(ad)
-            is_hamamatsu = 'Hamamatsu' in ad.detector_name(pretty=True)
             ad_tiled = self.tileArrays([ad], tile_all=False)[0]
             ad_fitted = astrodata.create(ad.phu)
             for ext, order, indices in zip(ad_tiled, orders, array_info.extensions):

--- a/geminidr/gmos/tests/__init__.py
+++ b/geminidr/gmos/tests/__init__.py
@@ -2,3 +2,4 @@
 """
 Tests for GMOS SQ Primitives.
 """
+CREATED_INPUTS_PATH_FOR_TESTS = "./dragons_test_inputs/geminidr/gmos/"

--- a/geminidr/gmos/tests/spect/test_extract_1d_spectra.py
+++ b/geminidr/gmos/tests/spect/test_extract_1d_spectra.py
@@ -26,14 +26,14 @@ from recipe_system.testing import ref_ad_factory
 # Test parameters --------------------------------------------------------------
 test_datasets = [
     "N20180508S0021_skyCorrected.fits",  # B600 720
-    # "N20180509S0010_skyCorrected.fits",  # R400 900
-    # "N20180516S0081_skyCorrected.fits",  # R600 860
-    # "N20190201S0163_skyCorrected.fits",  # B600 530
-    # "N20190313S0114_skyCorrected.fits",  # B600 482
-    # "N20190427S0123_skyCorrected.fits",  # R400 525
-    # "N20190427S0126_skyCorrected.fits",  # R400 625
-    # "N20190427S0127_skyCorrected.fits",  # R400 725
-    # "N20190427S0141_skyCorrected.fits",  # R150 660
+    # "N20180509S0010_aperturesTraced.fits",  # R400 900
+    # "N20180516S0081_aperturesTraced.fits",  # R600 860
+    # "N20190201S0163_aperturesTraced.fits",  # B600 530
+    # "N20190313S0114_aperturesTraced.fits",  # B600 482
+    # "N20190427S0123_aperturesTraced.fits",  # R400 525
+    # "N20190427S0126_aperturesTraced.fits",  # R400 625
+    # "N20190427S0127_aperturesTraced.fits",  # R400 725
+    # "N20190427S0141_aperturesTraced.fits",  # R150 660
 ]
 
 
@@ -164,23 +164,23 @@ def create_inputs_recipe():
     from geminidr.gmos.tests.spect import CREATED_INPUTS_PATH_FOR_TESTS
 
     associated_info = {
-        "N20180508S0021_skyCorrected.fits": {
+        "N20180508S0021_aperturesTraced.fits": {
             "arc": ["N20180615S0409.fits"], "center": 244},
-        "N20180509S0010_skyCorrected.fits": {
+        "N20180509S0010_aperturesTraced.fits": {
             "arc": ["N20180509S0080.fits"], "center": 259},
-        "N20180516S0081_skyCorrected.fits": {
+        "N20180516S0081_aperturesTraced.fits": {
             "arc": ["N20180516S0214.fits"], "center": 255},
-        "N20190201S0163_skyCorrected.fits": {
+        "N20190201S0163_aperturesTraced.fits": {
             "arc": ["N20190201S0176.fits"], "center": 255},
-        "N20190313S0114_skyCorrected.fits": {
+        "N20190313S0114_aperturesTraced.fits": {
             "arc": ["N20190313S0132.fits"], "center": 254},
-        "N20190427S0123_skyCorrected.fits": {
+        "N20190427S0123_aperturesTraced.fits": {
             "arc": ["N20190427S0266.fits"], "center": 260},
-        "N20190427S0126_skyCorrected.fits": {
+        "N20190427S0126_aperturesTraced.fits": {
             "arc": ["N20190427S0267.fits"], "center": 259},
-        "N20190427S0127_skyCorrected.fits": {
+        "N20190427S0127_aperturesTraced.fits": {
             "arc": ["N20190427S0268.fits"], "center": 258},
-        "N20190427S0141_skyCorrected.fits": {
+        "N20190427S0141_aperturesTraced.fits": {
             "arc": ["N20190427S0270.fits"], "center": 264},
     }
 
@@ -206,6 +206,7 @@ def create_inputs_recipe():
         print('Reducing ARC for {:s}'.format(data_label))
         logutils.config(file_name='log_arc_{}.txt'.format(data_label))
         arc_reduce = Reduce()
+        arc_reduce.mode = 'ql'
         arc_reduce.files.extend(arcs_path)
         arc_reduce.runr()
         arc_master = arc_reduce.output_filenames.pop()

--- a/geminidr/gmos/tests/test_add_padding_to_dq.py
+++ b/geminidr/gmos/tests/test_add_padding_to_dq.py
@@ -12,6 +12,7 @@ test_cases = [
 ]
 
 
+@pytest.mark.integration_test
 @pytest.mark.preprocessed_data
 @pytest.mark.parametrize("ad", test_cases, indirect=True)
 def test_add_padding_to_data(ad):
@@ -25,8 +26,9 @@ def test_add_padding_to_data(ad):
     adp = p.addPaddingToDQ().pop()
 
 
+@pytest.mark.integration_test
 @pytest.mark.preprocessed_data
-@pytest.mark.parametrize("ad", test_cases, indirect=True)
+@pytest.mark.parametrize("ad_tiled", test_cases, indirect=True)
 def test_add_padding_to_tiled_data(ad_tiled):
     """
     Test that the input did not have padded columns before calling
@@ -34,12 +36,12 @@ def test_add_padding_to_tiled_data(ad_tiled):
     calling the primitive in data that was not mosaicked nor tiled.
     """
     logutils.config(file_name='log_{}.txt'.format(ad.filename.strip('.fits')))
-    p = primitives_gmos.GMOS([ad])
+    p = primitives_gmos.GMOS([ad_tiled])
     adp = p.addPaddingToDQ().pop()
 
 
+@pytest.mark.integration_test
 @pytest.mark.preprocessed_data
-@pytest.mark.integration
 def test_add_padding_to_mosaicked_data():
     """
     ToDO: failed to create input data.

--- a/geminidr/gmos/tests/test_add_padding_to_dq.py
+++ b/geminidr/gmos/tests/test_add_padding_to_dq.py
@@ -24,12 +24,23 @@ def test_add_padding_to_data(ad):
     adp = p.addPaddingToDQ().pop()
 
 
-def test_add_padding_to_tiled_data():
-    pass
+@pytest.mark.parametrize("ad", test_cases, indirect=True)
+def test_add_padding_to_tiled_data(ad):
+    """
+    Test that the input did not have padded columns before calling
+    `p.addPaddingToDQ()` and that the padding was properly added after
+    calling the primitive in data that was not mosaicked nor tiled.
+    """
+    logutils.config(file_name='log_{}.txt'.format(ad.filename.strip('.fits')))
+    p = primitives_gmos.GMOS([ad])
+    adp = p.addPaddingToDQ().pop()
 
 
-def test_add_padding_to_mosaicked_data():
-    pass
+@pytest.mark.parametrize("ad_tiled", test_cases, indirect=True)
+def test_add_padding_to_mosaicked_data(ad_tiled):
+    logutils.config(file_name='log_{}.txt'.format(ad_tiled.filename.strip('.fits')))
+    p = primitives_gmos.GMOS([ad_tiled])
+    adp = p.addPaddingToDQ().pop()
 
 
 @pytest.fixture
@@ -43,6 +54,19 @@ def ad(request, path_to_inputs):
         raise FileNotFoundError(path)
 
     return ad
+
+
+@pytest.fixture
+def ad_tiled(request, path_to_inputs):
+    filename = request.param.replace(".fits", "_tiled.fits")
+    path = os.path.join(path_to_inputs, filename)
+
+    if os.path.exists(path):
+        _ad = astrodata.open(path)
+    else:
+        raise FileNotFoundError(path)
+
+    return _ad
 
 
 def create_inputs_recipe():

--- a/geminidr/gmos/tests/test_add_padding_to_dq.py
+++ b/geminidr/gmos/tests/test_add_padding_to_dq.py
@@ -12,6 +12,7 @@ test_cases = [
 ]
 
 
+@pytest.mark.preprocessed_data
 @pytest.mark.parametrize("ad", test_cases, indirect=True)
 def test_add_padding_to_data(ad):
     """
@@ -24,8 +25,9 @@ def test_add_padding_to_data(ad):
     adp = p.addPaddingToDQ().pop()
 
 
+@pytest.mark.preprocessed_data
 @pytest.mark.parametrize("ad", test_cases, indirect=True)
-def test_add_padding_to_tiled_data(ad):
+def test_add_padding_to_tiled_data(ad_tiled):
     """
     Test that the input did not have padded columns before calling
     `p.addPaddingToDQ()` and that the padding was properly added after
@@ -36,11 +38,13 @@ def test_add_padding_to_tiled_data(ad):
     adp = p.addPaddingToDQ().pop()
 
 
-@pytest.mark.parametrize("ad_tiled", test_cases, indirect=True)
-def test_add_padding_to_mosaicked_data(ad_tiled):
-    logutils.config(file_name='log_{}.txt'.format(ad_tiled.filename.strip('.fits')))
-    p = primitives_gmos.GMOS([ad_tiled])
-    adp = p.addPaddingToDQ().pop()
+@pytest.mark.preprocessed_data
+@pytest.mark.integration
+def test_add_padding_to_mosaicked_data():
+    """
+    ToDO: failed to create input data.
+    """
+    pass
 
 
 @pytest.fixture

--- a/geminidr/gmos/tests/test_add_padding_to_dq.py
+++ b/geminidr/gmos/tests/test_add_padding_to_dq.py
@@ -1,0 +1,84 @@
+import os
+import pytest
+
+import astrodata
+import gemini_instruments
+from geminidr.gmos import primitives_gmos
+from gempy.utils import logutils
+
+
+test_cases = [
+    "N20180508S0021.fits",  # GMOS-N Ham
+]
+
+
+@pytest.mark.parametrize("ad", test_cases, indirect=True)
+def test_add_padding_to_data(ad):
+    """
+    Test that the input did not have padded columns before calling
+    `p.addPaddingToDQ()` and that the padding was properly added after
+    calling the primitive in data that was not mosaicked nor tiled.
+    """
+    logutils.config(file_name='log_{}.txt'.format(ad.filename.strip('.fits')))
+    p = primitives_gmos.GMOS([ad])
+    adp = p.addPaddingToDQ().pop()
+
+
+def test_add_padding_to_tiled_data():
+    pass
+
+
+def test_add_padding_to_mosaicked_data():
+    pass
+
+
+@pytest.fixture
+def ad(request, path_to_inputs):
+    filename = request.param.replace(".fits", "_dqAdded.fits")
+    path = os.path.join(path_to_inputs, filename)
+
+    if os.path.exists(path):
+        ad = astrodata.open(path)
+    else:
+        raise FileNotFoundError(path)
+
+    return ad
+
+
+def create_inputs_recipe():
+    """
+    Creates static input data for the `addPaddingToDQ` tests.
+    """
+    from astrodata.testing import download_from_archive
+    from geminidr.gmos.tests import CREATED_INPUTS_PATH_FOR_TESTS
+
+    module_name, _ = os.path.splitext(os.path.basename(__file__))
+    path = os.path.join(CREATED_INPUTS_PATH_FOR_TESTS, module_name)
+    os.makedirs(path, exist_ok=True)
+    os.chdir(path)
+    os.makedirs("inputs/", exist_ok=True)
+    os.chdir("inputs/")
+    print('Current working directory:\n    {:s}'.format(os.getcwd()))
+
+    for filename in test_cases:
+        print('Downloading files...')
+        path = download_from_archive(filename)
+        ad = astrodata.open(path)
+        logutils.config(file_name='log_{}.txt'.format(filename.strip('.fits')))
+
+        p = primitives_gmos.GMOS([ad])
+        p.prepare()
+        p.addDQ(static_bpm=None)
+        p.writeOutputs()
+
+        p.tileArrays()
+        p.writeOutputs()
+
+        p.mosaicDetectors()
+        p.writeOutputs()
+
+
+if __name__ == '__main__':
+    from sys import argv
+    if '--create-inputs' in argv[1:]:
+        create_inputs_recipe()


### PR DESCRIPTION
I found that the p.normalizeFlat() for GMOS LS is masking out 21 pixels at the edges of each amplifier of Hamamatsu data. I was wondering the following:
1) Shouldn’t these paddings be applied only to the edges of each detector instead? At least this is how it appears in the static BPMs.
2) I see in the docstring that there is a TODO asking if we should add this to the BPM. The new script/module to create BPMs for GMOS adds these padding so we could remove them from here if everyone agrees.

This PR simply removes the lines where the padding is added.