### PR TITLE
Add a bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Provide specifics about a bug and provide outputted content with any errors
+title: 'Bug: ____(provide a descriptive name)'
+labels: bug
+assignees: ''
+
+---
+<!--Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL -->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+
+**Reproduction Steps**
+Steps to reproduce the behavior:
+1. Type the following in `ipython`: '...'
+
+
+**Outputted Messages / Screenshots**
+Provide the full message log or screenshot if possible or a subset that includes a few lines before the failure:
+
+
+**DRAGONS version**: (e.g., v2.1.1)
+
+
+*Expected behavior*
+A clear and concise description of what you expected to happen.
+
+
+*Additional context*
+Add any other context about the problem here.


### PR DESCRIPTION
An issue template can help both developers and users to communicate a development issue.

This here provides a 🐞  report template and will apply the `bug` label