### PR TITLE
Masking bad pixels in SpecViewer

### DIFF
--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -584,11 +584,13 @@ class Visualize(PrimitivesBASE):
                 w_units = str(ext.wcs.output_frame.unit[0])
 
                 # Clean up bad data
-                mask = np.logical_not(np.ma.masked_invalid(data).mask)
+                good_pixels = np.logical_and(
+                    ext.mask == 0,
+                    np.logical_not(np.ma.masked_invalid(data).mask))
 
-                wavelength = wavelength[mask]
-                data = data[mask].astype(float)
-                stddev = stddev[mask].astype(float)
+                wavelength = wavelength[good_pixels]
+                data = data[good_pixels].astype(float)
+                stddev = stddev[good_pixels].astype(float)
 
                 # Round and convert data/stddev to int to minimize data transfer load
                 wavelength = np.round(wavelength, decimals=3)

--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -583,16 +583,16 @@ class Visualize(PrimitivesBASE):
                 w_dispersion = np.abs(wavelength[-1] - wavelength[0]) / (data.size - 1)
                 w_units = str(ext.wcs.output_frame.unit[0])
 
-                # Clean up bad data
-                bad_pixels = np.logical_and(
-                    ext.mask > 0,
-                    np.ma.masked_invalid(data).mask)
+                # Create mask for bad data
+                mask = np.ma.masked_array(
+                    np.zeros_like(wavelength),
+                    mask=np.logical_or(
+                        ext.mask > 0, np.ma.masked_invalid(data).mask))
 
-                data[bad_pixels] = -10
-                stddev[bad_pixels] = -10
-
-                data = data.astype(float)
-                stddev = stddev.astype(float)
+                # Retrieve unmasked clump slices
+                _slices = [
+                    [int(s.start), int(s.stop)]
+                    for s in np.ma.clump_unmasked(mask)]
 
                 # Round and convert data/stddev to int to minimize data transfer load
                 wavelength = np.round(wavelength, decimals=3)
@@ -620,6 +620,7 @@ class Visualize(PrimitivesBASE):
                     "id": np.round(center + offset),
                     "intensity": _intensity,
                     "intensity_units": _units,
+                    "slices": _slices,
                     "stddev": _stddev,
                 }
 

--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -584,13 +584,15 @@ class Visualize(PrimitivesBASE):
                 w_units = str(ext.wcs.output_frame.unit[0])
 
                 # Clean up bad data
-                good_pixels = np.logical_and(
-                    ext.mask == 0,
-                    np.logical_not(np.ma.masked_invalid(data).mask))
+                bad_pixels = np.logical_and(
+                    ext.mask > 0,
+                    np.ma.masked_invalid(data).mask)
 
-                wavelength = wavelength[good_pixels]
-                data = data[good_pixels].astype(float)
-                stddev = stddev[good_pixels].astype(float)
+                data[bad_pixels] = -10
+                stddev[bad_pixels] = -10
+
+                data = data.astype(float)
+                stddev = stddev.astype(float)
 
                 # Round and convert data/stddev to int to minimize data transfer load
                 wavelength = np.round(wavelength, decimals=3)

--- a/recipe_system/adcc/client/qap_specviewer/css/specviewer.css
+++ b/recipe_system/adcc/client/qap_specviewer/css/specviewer.css
@@ -3,6 +3,8 @@ body {
   color: black;
   font: normal normal 16px Verdana, Geneva, Arial, Helvetica, sans-serif;
   padding: 10px;
+  max-width: 1040px;
+  margin: auto;
 }
 
 button.settings {

--- a/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
+++ b/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
@@ -23,6 +23,9 @@ const plotOptions = {
     },
     shadow: false,
     renderer: $.jqplot.LineRenderer,
+    rendererOptions: {
+      smooth: false,
+    }
   },
 
   series: [{

--- a/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
+++ b/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
@@ -28,18 +28,6 @@ const plotOptions = {
     }
   },
 
-  // series: [{
-  //     color: 'rgba(46, 134, 193, 1.0)',
-  //     label: 'Intensity',
-  //     shadow: false,
-  //   },
-  //   {
-  //     color: 'rgba(211, 96, 0, 0.2)',
-  //     label: 'Standard Deviation',
-  //     shadow: false,
-  //   },
-  // ],
-
   grid: {
     background: 'white',
     drawBorder: false,
@@ -636,11 +624,10 @@ class SpecViewer {
         async function() {
           console.log(`Reset zoom of ${type} plot #${i}.`);
           p.resetZoom();
+          remove_extra_items_from_legend(i);
           sleep(250);
         }
       );
-
-      remove_extra_items_from_legend(i);
 
   } //
 

--- a/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
+++ b/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
@@ -389,8 +389,8 @@ function isInApertureList(aperture, pixelScale, listOfApertures) {
  *
  * @param {number} idx - Aperture index
  */
-function remove_extra_items_from_legend(idx) {
-  let legend_items = $(`table.jqplot-table-legend:eq(${idx}) tr`);
+function remove_extra_items_from_legend(plotId) {
+  let legend_items = $(`#${plotId} table.jqplot-table-legend tr`);
   for (let j = legend_items.length-1; j > 0; j--) {
     if (j != legend_items.length / 2) { legend_items[j].remove(); }}
 }
@@ -635,6 +635,7 @@ class SpecViewer {
 
       let sViewer = this;
       let apId = sViewer.aperturesId[i];
+      let plotId = `${type}Plot_${apId}`;
 
       function sleep (miliseconds) {
         return new Promise(resolve => setTimeout(resolve, miliseconds));
@@ -648,7 +649,7 @@ class SpecViewer {
         async function() {
           console.log(`Reset zoom of ${type} plot #${i}.`);
           p.resetZoom();
-          remove_extra_items_from_legend(i);
+          remove_extra_items_from_legend(plotId);
           sleep(250);
         }
       );
@@ -733,6 +734,7 @@ class SpecViewer {
 
     for (let i = 0; i < this.aperturesId.length; i++) {
 
+      let sViewer = this;
       let apertureId = this.aperturesId[i];
       let plotId = `${type}Plot_${apertureId}`;
       let activeTabIndex = $(`#${this.id}`).tabs('option', 'active');
@@ -780,8 +782,9 @@ class SpecViewer {
           console.log('Refresh plots');
 
           slices.map(function (s, idx) {
-            this[`${type}Plots`][i].series[idx].data = intensity.slice(s[0], s[1]);
-            this[`${type}Plots`][i].series[idx + slices.length].data = stddev.slice(s[0], s[1]);
+            console.log(s);
+            sViewer[`${type}Plots`][i].series[idx].data = intensity.slice(s[0], s[1]);
+            sViewer[`${type}Plots`][i].series[idx + slices.length].data = stddev.slice(s[0], s[1]);
           })
 
           this[`${type}Plots`][i].title.text = plotTitle;
@@ -837,16 +840,15 @@ class SpecViewer {
           );
 
           // Clean up the legend
-          remove_extra_items_from_legend(i);
+          remove_extra_items_from_legend(plotId);
 
           // Customize doZoom to clean up the legend after zooming.
           let sViewer = this;
           let originalDoZoom = this[`${type}Plots`][i].plugins.cursor.doZoom;
 
           this[`${type}Plots`][i].plugins.cursor.doZoom = function (gridpos, datapos, plot, cursor) {
-            let activeTabIndex = $(`#${sViewer.id}`).tabs('option', 'active');
             originalDoZoom(gridpos, datapos, plot, cursor);
-            remove_extra_items_from_legend(activeTabIndex);
+            remove_extra_items_from_legend(plotId);
           }
 
         } else {
@@ -879,6 +881,7 @@ class SpecViewer {
     function resizePlotArea(index, type) {
       let apId = sViewer.aperturesId[index];
       let plotInstance = sViewer[`${type}Plots`][index];
+      let plotId = `${type}Plot_${apId}`;
       let plotTarget = $(`#${type}Plot_${apId}`);
       let resizableArea = $(`#aperture${apId} .resizable.${type}`);
 
@@ -897,7 +900,7 @@ class SpecViewer {
         );
       }
 
-      remove_extra_items_from_legend(index);
+      remove_extra_items_from_legend(plotId);
 
     }
 

--- a/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
+++ b/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
@@ -52,6 +52,7 @@ const plotOptions = {
 
 };
 
+
 /**
  * Adds a count down in the footer to let user know when the server was queried.
  * @param {object} sViewer - An initialized version of SpecViewer.
@@ -83,6 +84,7 @@ function addCountDown(sViewer) {
   } // end updateCountdown
   setInterval(updateCountdown, 1000);
 }  // end addCountDown
+
 
 /**
  * Add the settings button and the hidden form to the webpage.
@@ -133,6 +135,7 @@ function addSettings(sViewer) {
   function showSettings () {
     console.log("Clicked on settings button.");
     settingsModal.css("display", "block");
+    queryFreq.focus();
   };
 
   function saveSettings () {
@@ -146,6 +149,7 @@ function addSettings(sViewer) {
   function cancel() {
     settingsModal.css("display", "none");
     queryFreq.val(sViewer.delay / 1000);
+    console.log(` Discarding changes.`);
   };
 
   // Add functionality to buttons
@@ -154,14 +158,29 @@ function addSettings(sViewer) {
   $( '#cancelBtn' ).unbind("click").on( "click", cancel );
   $( '.close' ).unbind("click").on( "click", cancel );
 
+  // Add keybinding
+  $(document).keypress(function(event) {
+    if (settingsModal.css("display") === "block") {
+
+      // Accept settings if Enter pressed
+      if (event.key === "Enter") { saveSettings(); }
+
+      // Cancel if Esc pressed
+      if (event.key === "Escape") { cancel(); }
+
+    }
+  });
+
   // Close settings if clicked outside
   window.onclick = function(event) {
     if (event.target.id == "settings") {
       cancel();
     }
+
   }
 
 }
+
 
 /**
  * Makes sure that every incoming aperture is unique.
@@ -185,6 +204,7 @@ function assureUniqueApertures(apertures) {
   return uniqueApertures;
 
 } // end assureUniqueApertures
+
 
 /**
  * Returns the Aperture Info div element using a template.
@@ -210,6 +230,7 @@ function getApertureInfo(aperture) {
 
 }
 
+
 /**
  * Get element value inside `list` that is the nearest to the `target` value.
  * @param  {number} target - Target value
@@ -227,6 +248,7 @@ function getNearest(target, list) {
   return nearest;
 
 }
+
 
 /**
  * Returns the index of the element inside `list` that is the nearest tho the
@@ -308,6 +330,7 @@ function getStackInfo(filename, programId) {
   `;
 }
 
+
 /**
  * Convert input units to be used as label to the x-axis.
  * @param {string} units
@@ -335,6 +358,7 @@ function getWavelengthUnits(units) {
   }
 
 }
+
 
 /**
  * Gets the nearest aperture id value inside `listOfApertures` and verify
@@ -812,7 +836,18 @@ class SpecViewer {
             })
           );
 
+          // Clean up the legend
           remove_extra_items_from_legend(i);
+
+          // Customize doZoom to clean up the legend after zooming.
+          let sViewer = this;
+          let originalDoZoom = this[`${type}Plots`][i].plugins.cursor.doZoom;
+
+          this[`${type}Plots`][i].plugins.cursor.doZoom = function (gridpos, datapos, plot, cursor) {
+            let activeTabIndex = $(`#${sViewer.id}`).tabs('option', 'active');
+            originalDoZoom(gridpos, datapos, plot, cursor);
+            remove_extra_items_from_legend(activeTabIndex);
+          }
 
         } else {
           $(`#${plotId}`).html(noData);

--- a/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
+++ b/recipe_system/adcc/client/qap_specviewer/js/specviewer.js
@@ -782,7 +782,6 @@ class SpecViewer {
           console.log('Refresh plots');
 
           slices.map(function (s, idx) {
-            console.log(s);
             sViewer[`${type}Plots`][i].series[idx].data = intensity.slice(s[0], s[1]);
             sViewer[`${type}Plots`][i].series[idx + slices.length].data = stddev.slice(s[0], s[1]);
           })


### PR DESCRIPTION
Given the limitations of JQPlot, bad pixels were not being properly masked in the past. Now the `plotSpectraForQA` passes a list of slice objects to ADCC and SpecViewer uses this list to plot the intensity and the standard deviation as multiple series. 
Since we had multiple series, I had to come up with a solution that cleaned up the legend, preventing repeated representations of each series. This was implemented and wrapped up in several places that updated the plot, including the `doZoom` function from JQPlot. The results now seem fine and it seems to run as expected. 


 