### PR TITLE
bugfix for IRAF processed flat detection

### DIFF
--- a/gemini_instruments/gemini/adclass.py
+++ b/gemini_instruments/gemini/adclass.py
@@ -233,7 +233,7 @@ class AstroDataGemini(AstroDataFits):
     @astro_data_tag
     def _status_processed_cals(self):
         kwords = {'PROCARC', 'GBIAS', 'PROCBIAS', 'PROCDARK',
-                      'GIFLAG', 'PROCFLAT', 'GIFRINGE', 'PROCFRNG', 'PROCSTND', 'PROCILLM'}
+                      'GIFLAT', 'PROCFLAT', 'GIFRINGE', 'PROCFRNG', 'PROCSTND', 'PROCILLM'}
 
         if set(self.phu.keys()) & kwords:
             return TagSet(['PROCESSED'])


### PR DESCRIPTION
The detection of IRAF processed flats is failing with a misnamed header check.  This updates the AstroDataGemini to look for GIFLAT correctly.