### PR TITLE
bugfix/fit1dtabs widgets all operate on tab1 data

### DIFF
--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -322,7 +322,7 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
     slider.width = slider_width
 
     text_input = TextInput(width=64, value=str(value))
-    component = row(slider, text_input, id=attr)
+    component = row(slider, text_input, css_classes=["text_sider_%s" % attr,])
 
     def _input_check(val):
         # Check if the value is viable as an int or float, according to our type


### PR DESCRIPTION
With id being set in the text inputs for each tab, the subsequent bokeh widgets with the same id get discarded and each tab only shows the widgets from the initial one.  This moves to using css classes to target each slider by param name.