### PR TITLE
Use NDAstroData.unit

### DIFF
--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -588,9 +588,16 @@ def ad_to_hdulist(ad):
                 if 'APPROXIMATE' not in wcs_dict.get('FITS-WCS', ''):
                     wcs = None  # There's no need to create a WCS extension
 
-        hdul.append(new_imagehdu(ext.data, header, 'SCI'))
+        data_hdu = new_imagehdu(ext.data, header, 'SCI')
+
+        if ext.unit is not None and ext.unit is not u.dimensionless_unscaled:
+            data_hdu.header['BUNIT'] = ext.unit.to_string()
+
+        hdul.append(data_hdu)
+
         if ext.uncertainty is not None:
             hdul.append(new_imagehdu(ext.uncertainty.array, header, 'VAR'))
+
         if ext.mask is not None:
             hdul.append(new_imagehdu(ext.mask, header, 'DQ'))
 

--- a/astrodata/fits.py
+++ b/astrodata/fits.py
@@ -30,6 +30,12 @@ DEFAULT_EXTENSION = 'SCI'
 NO_DEFAULT = object()
 LOGGER = logging.getLogger(__name__)
 
+known_invalid_fits_unit_strings = {
+    'ELECTRONS/S': u.electron/u.s,
+    'ELECTRONS': u.electron,
+    'electrons': u.electron,
+}
+
 
 class FitsHeaderCollection:
     """Group access to a list of FITS Header-like objects.
@@ -391,7 +397,7 @@ def _prepare_hdulist(hdulist, default_extension='SCI', extname_parser=None):
     return HDUList(sorted(new_list, key=fits_ext_comp_key))
 
 
-def read_fits(cls, source, extname_parser=None):
+def read_fits(cls, source, extname_parser=None, default_unit='adu'):
     """
     Takes either a string (with the path to a file) or an HDUList as input, and
     tries to return a populated AstroData (or descendant) instance.
@@ -477,12 +483,24 @@ def read_fits(cls, source, extname_parser=None):
                 not isinstance(parts['uncertainty'], FitsLazyLoadable)):
             parts['uncertainty'] = ADVarianceUncertainty(parts['uncertainty'])
 
+        bunit = header.get('BUNIT')
+        if bunit:
+            if bunit in known_invalid_fits_unit_strings:
+                bunit = known_invalid_fits_unit_strings[bunit]
+            try:
+                unit = u.Unit(bunit, format='fits')
+            except ValueError:
+                unit = u.Unit(default_unit)
+        else:
+            unit = u.Unit(default_unit)
+
         # Create the NDData object
         nd = NDDataObject(
             data=parts['data'],
             uncertainty=parts['uncertainty'],
             mask=parts['mask'],
             meta={'header': header},
+            unit=unit,
         )
 
         if parts['wcs'] is not None:

--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -8,8 +8,8 @@ import warnings
 from copy import deepcopy
 from functools import reduce
 
+import astropy.units as u
 import numpy as np
-
 from astropy.io.fits import ImageHDU
 from astropy.modeling import Model, models
 from astropy.nddata import (NDArithmeticMixin, NDData, NDSlicingMixin,
@@ -368,6 +368,18 @@ class NDAstroData(NDArithmeticMixin, NDSlicingMixin, NDData):
     def variance(self, value):
         self.uncertainty = (ADVarianceUncertainty(value) if value is not None
                             else None)
+
+    # Override unit so that we can add a setter.
+    @property
+    def unit(self):
+        return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        if value is None:
+            self._unit = None
+        else:
+            self._unit = u.Unit(value)
 
     def set_section(self, section, input):
         """


### PR DESCRIPTION
This was suggested by @chris-simpson in Trac#828, cc @KathleenLabrie as well.

This PR allows to read the unit from BUNIT and set it to `NDAstroData.unit`, and the opposite when writing files.
However there is a problem with this. When a `NDData` object has a unit, then it uses this unit in computations (using Astropy `Quantity` objects). Which means that all operands should have a unit. Adding or subtracting a scalar or a Numpy array without a unit raises a `UnitConversionError`.

There are I think 3 solutions:
- forget about this change ;)
- update the code everywhere to use units ...
- or we could probably customize the arithmetic code in NDAstroData so we don't require the operand to have a unit. But then we loose the benefits of having units, so not sure about this.

Another thing to mention here is that currently there is a small performance overhead when doing arithmetic with NDData, because it uses `self.data * self.unit` to attach the unit which makes a copy of the array. This could be fixed by changing the code in Astropy to use `self.data << self.unit` which does not make a copy: https://github.com/astropy/astropy/pull/11107