### PR TITLE
adding region editor for normalizeFlat

### DIFF
--- a/geminidr/gmos/primitives_gmos_longslit.py
+++ b/geminidr/gmos/primitives_gmos_longslit.py
@@ -729,7 +729,7 @@ class GMOSLongslit(GMOSSpect, GMOSNodAndShuffle):
                                                    primitive_name="normalizeFlat",
                                                    filename_info=filename_info,
                                                    enable_user_masking=False,
-                                                   enable_regions=False,
+                                                   enable_regions=True,
                                                    help_text=NORMALIZE_FLAT_HELP_TEXT,
                                                    recalc_inputs_above=True)
                 geminidr.interactive.server.interactive_fitter(visualizer)

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -543,8 +543,10 @@ class Fit1DPanel:
             height of plot area in pixels
         plot_residuals : bool
             True if we want the lower plot showing the differential between the fit and the data
-        grow_slider : bool
-            True if we want the slider for modifying growth radius
+        enable_user_masking : bool
+            True to enable fine-grained data masking by the user using bokeh selections
+        enable_regions : bool
+            True if we want to allow user-defind regions as a means of masking the data
         """
         # Just to get the doc later
         self.visualizer = visualizer


### PR DESCRIPTION
This patch:
* adds the region editing per CCD in normalizeFlat
* fixes logic that sorts the region tuples in case of Nones, which are now legal for open-ended regions
* maps regions back into the fit model when using the text box, so they can be re-extracted when normalizeFlat generates fresh fits with the same parameters.