### PR TITLE
Punting and using a fixed CSS crosshair cursor for the bokeh figure area

### DIFF
--- a/geminidr/interactive/static/dragons.css
+++ b/geminidr/interactive/static/dragons.css
@@ -197,3 +197,7 @@ div.plot_tools_help div {
 div.plot_tools_help div span {
     margin-left: 4px;
 }
+
+.bk-canvas-events {
+    cursor: crosshair;
+}


### PR DESCRIPTION
It seems quite difficult to tap into the bokeh Toolbar in any meaningful way, so I've resorted to an always-on crosshair cursor via CSS for the figure area.