### PR TITLE
detecting any exception when running the subprocess loop

### DIFF
--- a/gempy/eti_core/eti.py
+++ b/gempy/eti_core/eti.py
@@ -21,11 +21,12 @@ def loop_process(in_queue, out_queue):
     while True:
         try:
             cmd = in_queue.get()
-
             try:
                 result = check_output(cmd, stderr=STDOUT)
             except CalledProcessError as e:
                 result = e
+            except Exception as ex:
+                result = ex
             out_queue.put(result)
         except KeyboardInterrupt:
             continue


### PR DESCRIPTION
Unexpected exceptions cause the loop to exit, but since a result is not placed on the output queue, the upstream logic waits forever.  Instead, I propose catching any unexpected exceptions and adding them to the queue as well.

I tested this for the case I ran into, which was a FileNotFoundException when the required program was not in the PATH.