### PR TITLE
Bugfix/187 remove select help for norm flat

### DIFF
--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -636,8 +636,11 @@ class Fit1DPanel:
 
             connect_figure_extras(p_main, None, self.band_model)
 
-            mask_handlers = (self.mask_button_handler,
-                             self.unmask_button_handler)
+            if enable_user_masking:
+                mask_handlers = (self.mask_button_handler,
+                                 self.unmask_button_handler)
+            else:
+                mask_handlers = None
         else:
             self.band_model = None
             mask_handlers = None


### PR DESCRIPTION
It was passing selection mask handler methods to the controller if region masking was enabled.  But for normalizeFlat we support regions only and not selection masking.

No longer sending the handlers if selection is disabled in the fit1d.