### PR TITLE
handling inverted inputs during parse of regions string

### DIFF
--- a/gempy/library/astrotools.py
+++ b/gempy/library/astrotools.py
@@ -190,6 +190,8 @@ def parse_user_regions(regions, dtype=int, allow_step=False):
             values = [dtype(x) if x else None
                       for x in range_.replace("-", ":", 1).split(":")]
             assert len(values) in (1, 2, 2+allow_step)
+            if len(values) > 1 and values[0] is not None and values[1] is not None and values[0] > values[1]:
+                values[0], values[1] = values[1], values[0]
         except (ValueError, AssertionError):
             raise ValueError(f"Failed to parse sample regions '{regions}'")
         ranges.append(tuple(values))

--- a/gempy/library/tests/test_astrotools.py
+++ b/gempy/library/tests/test_astrotools.py
@@ -88,6 +88,7 @@ def test_parse_user_regions():
     assert parse("1:10,20:50:2", allow_step=True) == [(1, 10), (20, 50, 2)]
     with pytest.raises(ValueError):
         parse("1:10:2")
+    assert parse("50:20") == [(20, 50), ]
 
 
 def test_cartesian_regions_to_slices():


### PR DESCRIPTION
If the start of the range is bigger than the end, flip them automatically during parsing