### PR TITLE
Removed old logic that was updating the list of editors

### DIFF
--- a/geminidr/interactive/fit/aperture.py
+++ b/geminidr/interactive/fit/aperture.py
@@ -766,8 +766,6 @@ class ApertureView:
     def update_viewport_callback(self, start, end):
         self._pending_update_viewport = False
         self._reload_holoviews()
-        for widget in self.widgets.values():
-            widget[1].update_viewport(start, end)
 
     def update_aperture(self, aperture_id):
         """Handle an updated or added aperture."""


### PR DESCRIPTION
The old logic was still in place to modify slider ranges and disable/enable for the set of editors per aperture.  We no longer have those and that was causing the stack trace error.