### PR TITLE
Safari websocket issues fix by removing heartbeat

### DIFF
--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -69,15 +69,10 @@ class PrimitiveVisualizer(ABC):
         # Remove this line if we stick with that
         # self.submit_button.on_click(self.submit_button_handler)
         callback = CustomJS(code="""
-            $.ajax('/shutdown').done(function() {
-                window.close();
+            $.ajax('/shutdown').done(function()
+                {
+                    window.close();
                 });
-            
-            //console.log('in button callback');
-            //$.ajax('/shutdown').done(function() {
-            //    console.log('shutdown succeeded');
-            //    delayed_close();
-            //});
         """)
         self.submit_button.js_on_click(callback)
         self.doc = None
@@ -414,7 +409,6 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
         text_input.js_on_change('value', CustomJS(
             args=dict(inp=text_input),
             code="""
-                debugger;
                 if (inp.value > %s) {
                     alert('Maximum is %s');
                     inp.value = %s;
@@ -424,7 +418,6 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
         text_input.js_on_change('value', CustomJS(
             args=dict(inp=text_input),
             code="""
-                debugger;
                 if (inp.value < %s) {
                     alert('Minimum is %s');
                     inp.value = %s;

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -69,10 +69,15 @@ class PrimitiveVisualizer(ABC):
         # Remove this line if we stick with that
         # self.submit_button.on_click(self.submit_button_handler)
         callback = CustomJS(code="""
-            $.ajax('/shutdown').done(function() 
-                {
-                    window.close();
+            $.ajax('/shutdown').done(function() {
+                window.close();
                 });
+            
+            //console.log('in button callback');
+            //$.ajax('/shutdown').done(function() {
+            //    console.log('shutdown succeeded');
+            //    delayed_close();
+            //});
         """)
         self.submit_button.js_on_click(callback)
         self.doc = None

--- a/geminidr/interactive/server.py
+++ b/geminidr/interactive/server.py
@@ -195,6 +195,20 @@ def start_server():
         port = 5006
         while port < 5701 and _bokeh_server is None:
             try:
+                # NOTE:
+                # Tornado generates a WebSocketClosedError when the user
+                # is on Safari.  This seems to be a regression as Safari
+                # has had this problem before with bokeh and web scokets.
+                # Chrome and FireFox work fine.
+                #
+                # To get Safari to behave, I have added the
+                # keep_alive_milliseconds=0 argument below.  This
+                # disables the keep alive heartbeat that causes the
+                # above error.  If you remove that argument, bokeh
+                # will re-enable the heartbeat but Safari won't work
+                # in interactive mode any more.  See below for a way
+                # to make interactive use "chrome" (or "firefox")
+                # regardless of the selected browser if desired.
                 _bokeh_server = Server(
                     {
                         '/': _bkapp,
@@ -204,6 +218,7 @@ def start_server():
                         '/help': _helpapp,
                         '/shutdown': _shutdown,
                     },
+                    keep_alive_milliseconds=0,
                     num_procs=1,
                     extra_patterns=[('/version', VersionHandler)],
                     port=port)
@@ -213,7 +228,8 @@ def start_server():
                     raise
         _bokeh_server.start()
 
-    _bokeh_server.io_loop.add_callback(_bokeh_server.show, "/", browser="chrome")
+    # to force a browser, add browser="chrome" tp this add_callback
+    _bokeh_server.io_loop.add_callback(_bokeh_server.show, "/")
     _bokeh_server.io_loop.start()
 
     # The server normally stops when the user hits the Submit button in the

--- a/geminidr/interactive/server.py
+++ b/geminidr/interactive/server.py
@@ -1,4 +1,5 @@
 import uuid
+from time import sleep
 
 from astrodata import version
 
@@ -212,7 +213,7 @@ def start_server():
                     raise
         _bokeh_server.start()
 
-    _bokeh_server.io_loop.add_callback(_bokeh_server.show, "/")
+    _bokeh_server.io_loop.add_callback(_bokeh_server.show, "/", browser="chrome")
     _bokeh_server.io_loop.start()
 
     # The server normally stops when the user hits the Submit button in the

--- a/geminidr/interactive/server.py
+++ b/geminidr/interactive/server.py
@@ -1,5 +1,4 @@
 import uuid
-from time import sleep
 
 from astrodata import version
 

--- a/geminidr/interactive/templates/index.html
+++ b/geminidr/interactive/templates/index.html
@@ -78,6 +78,27 @@
 </div> <!-- end container -->
 
 <script type="text/javascript">
+    // we have to wait for the server to drop or
+    // Safari will cause stack traces in Tornado
+    // in the bokeh server.
+    function delayed_close() {
+        console.log('in delayed_close');
+        $.ajax({
+                url: '/dragons',
+                timeout: 100
+                }).done(function() {
+            // try again in 1/4 second
+            console.log('call to /dragons succeeded, sleeping 250ms and retrying');
+            setTimeout(delayed_close, 250);
+        }).fail(function() {
+            console.log('call to /dragons failed, we can close the browser now');
+            debugger;
+            window.close();
+        });
+    };
+</script>
+
+<script type="text/javascript">
     // $("#plot_div").keydown(function(event) {
     // document.getElementById("plot_div").addEventListener("keydown", function(event){
     // doing whole document.  Or we could figure out how to target a bokeh-generated container div

--- a/geminidr/interactive/templates/index.html
+++ b/geminidr/interactive/templates/index.html
@@ -78,27 +78,6 @@
 </div> <!-- end container -->
 
 <script type="text/javascript">
-    // we have to wait for the server to drop or
-    // Safari will cause stack traces in Tornado
-    // in the bokeh server.
-    function delayed_close() {
-        console.log('in delayed_close');
-        $.ajax({
-                url: '/dragons',
-                timeout: 100
-                }).done(function() {
-            // try again in 1/4 second
-            console.log('call to /dragons succeeded, sleeping 250ms and retrying');
-            setTimeout(delayed_close, 250);
-        }).fail(function() {
-            console.log('call to /dragons failed, we can close the browser now');
-            debugger;
-            window.close();
-        });
-    };
-</script>
-
-<script type="text/javascript">
     // $("#plot_div").keydown(function(event) {
     // document.getElementById("plot_div").addEventListener("keydown", function(event){
     // doing whole document.  Or we could figure out how to target a bokeh-generated container div


### PR DESCRIPTION
There is a websocket keepalive heartbeat in bokeh that Safari doesn't handle right.  I suspect we don't need the heartbeat for our use case - running the embedded bokeh server with no webserver between it and the browser.