### PR TITLE
bugfix/handle recalc points errors

### DIFF
--- a/geminidr/interactive/INTERACTIVE.md
+++ b/geminidr/interactive/INTERACTIVE.md
@@ -191,6 +191,15 @@ The only standard method is `visualize`.  You should provide a method/fields for
 primitive to access the results of your custom fit.  In the case of the `Fit1DVisualizer1`,
 this call is `results()`
 
+### show_user_message
+
+There is a helper method called `show_user_message` that will pop up a message dialog 
+for the user.  As an example:
+
+```python
+self.vis.show_user_message(f"Sigma slider changed to {val}")
+```
+
 ### make_modal
 
 There is a helper method called `make_modal` that will pop up a message in the webpage

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -1262,6 +1262,7 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
         if self.modal_widget:
             self.modal_widget.disabled = True
 
+        rollback_config = {k: v for k, v in self.config.items()}
         def fn():
             """Top-level code to update the Config with the values from the widgets"""
             config_update = {k: v.value for k, v in self.widgets.items()}
@@ -1275,14 +1276,23 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
 
         if self.reconstruct_points_fn is not None:
             def rfn():
-                all_coords = self.reconstruct_points_fn(self.config, self.extras)
-                for fit, coords in zip(self.fits, all_coords):
-                    if len(coords) > 2:
-                        fit.weights = coords[2]
-                    else:
-                        fit.weights = None
-                    fit.weights = fit.populate_bokeh_objects(coords[0], coords[1], fit.weights, mask=None)
-                    fit.perform_fit()
+                all_coords = None
+                try:
+                    all_coords = self.reconstruct_points_fn(self.config, self.extras)
+                except Exception as e:
+                    # something went wrong, let's revert the inputs
+                    # handling immediately to specifically trap the reconstruct_points_fn call
+                    self.config.update(**rollback_config)
+                    self.show_user_message("Unable to build data from inputs, reverting")
+                if all_coords is not None:
+                    for fit, coords in zip(self.fits, all_coords):
+                        if len(coords) > 2:
+                            fit.weights = coords[2]
+                        else:
+                            fit.weights = None
+                        fit.weights = fit.populate_bokeh_objects(coords[0], coords[1], fit.weights, mask=None)
+                        fit.perform_fit()
+
                 if self.modal_widget:
                     self.modal_widget.disabled = False
 

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -6,7 +6,7 @@ from functools import cmp_to_key
 from bokeh.core.property.instance import Instance
 from bokeh.layouts import column, row
 from bokeh.models import (BoxAnnotation, Button, CustomJS, Dropdown,
-                          NumeralTickFormatter, RangeSlider, Slider, TextInput, Div, NumericInput)
+                          NumeralTickFormatter, RangeSlider, Slider, TextInput, Div, NumericInput, PreText)
 from bokeh import models as bm
 
 from geminidr.interactive import server
@@ -165,6 +165,22 @@ class PrimitiveVisualizer(ABC):
         # doc.add_root(self._ok_cancel_dlg.layout)
         # Add an OK/Cancel dialog we can tap into later
 
+        # Add a widget we can use for triggering a message
+        # This is a workaround, since CustomJS calls can only
+        # respond to DOM events.  We'll be able to trigger
+        # a Custom JS callback by modifying this widget
+        self.message_holder = PreText(text='', css_classes=['hidden'])
+        callback = CustomJS(args={}, code='alert(cb_obj.text);')
+        self.message_holder.js_on_change('text', callback)
+
+        # Add the invisible PreText element to drive message dialogs off
+        # of.  We do this with a do_later so that it will hapen after the
+        # subclass implementation does all of it's document setup.  So,
+        # this widget will be added at the end.
+        def add_msg_holder_hack():
+            doc.add_root(row(self.message_holder,))
+        self.do_later(add_msg_holder_hack)
+
     def do_later(self, fn):
         """
         Perform an operation later, on the bokeh event loop.
@@ -217,6 +233,26 @@ class PrimitiveVisualizer(ABC):
             }
         """ % message)
         widget.js_on_change('disabled', callback)
+
+    def show_user_message(self, message):
+        """
+        Make a modal message dialog to display to the user.
+
+        Parameters
+        ----------
+        message : str
+            message to display in the popup modal
+        """
+        # In the constructor, we setup this throwaway widget
+        # so we could listen for changes in it's text field
+        # and display those via an alert.  It's a workaround
+        # so that here we can send messages to the user from
+        # the bokeh server-side python.
+        if self.message_holder.text == message:
+            # need to trigger a change...
+            self.message_holder.text = f"{message} "
+        else:
+            self.message_holder.text = message
 
     def make_widgets_from_config(self, params, extras, reinit_live,
                                  slider_width=256):


### PR DESCRIPTION
When the fitter calls the supplied function to recalculate input points (if applicable), it will trap any exceptions and revert the input values without modifying the points.  A popup message alerts the user this has happened.