### PR TITLE
Added a pad_buttons option for Fit1DVisualizer

### DIFF
--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -1008,7 +1008,7 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
                  tab_name_fmt='{}', xlabel='x', ylabel='y',
                  domains=None, title=None, primitive_name=None, filename_info=None,
                  template="fit1d.html", help_text=None, recalc_inputs_above=False,
-                 ui_params=None, turbo_tabs=False, panel_class=Fit1DPanel,
+                 ui_params=None, turbo_tabs=False, panel_class=Fit1DPanel, pad_buttons=False,
                  **kwargs):
         """
         Parameters
@@ -1060,11 +1060,14 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
             The class of Panel to use in each tab. This allows specific
             operability for each primitive since most of the functions that do
             the work are methods of this class.
+        pad_buttons : bool
+            If True, pad the abort/accept buttons so the tabs can flow under them
         """
         super().__init__(title=title, primitive_name=primitive_name, filename_info=filename_info,
                          template=template, help_text=help_text, ui_params=ui_params)
         self.layout = None
         self.recalc_inputs_above = recalc_inputs_above
+        self.pad_buttons = pad_buttons
 
         # Make the widgets accessible from external code so we can update
         # their properties if the default setup isn't great
@@ -1245,7 +1248,7 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
             btn.align = 'end'
             btn.height = 35
             btn.height_policy = "fixed"
-            btn.margin = (0, 5, -20, 5)
+            btn.margin = (0, 5, -20 if not self.pad_buttons else 0, 5)
             btn.width = 212
             btn.width_policy = "fixed"
 

--- a/geminidr/interactive/fit/tracing.py
+++ b/geminidr/interactive/fit/tracing.py
@@ -64,6 +64,7 @@ def interactive_trace_apertures(ext, fit1d_params, ui_params: UIParameters):
         modal_message="Tracing apertures...",
         ui_params=ui_params,
         turbo_tabs=True,
+        pad_buttons=True
     )
 
     server.interactive_fitter(visualizer)


### PR DESCRIPTION
This option leaves space for the tabs to flow under the buttons, used by trace_apertures.

Alternatively, we could remove the option and drive the behavior off of the tab count.
