### PR TITLE
adding back compatible support to run against the new GeminiCalMgr code

### DIFF
--- a/recipe_system/cal_service/localmanager.py
+++ b/recipe_system/cal_service/localmanager.py
@@ -90,22 +90,30 @@ class LocalManager:
         are affected by the change. Then it sets a new database session object
         for this instance.
         """
-
         fsc.storage_root = abspath(dirname(self._db_path))
         fsc.fits_dbname = basename(self._db_path)
         fsc.db_path = self._db_path
         fsc.fits_database = 'sqlite:///' + fsc.db_path
 
-        # The reloading is kludgy, but Fits Storage was not designed to change
-        # databases on the fly, and we're reusing its infrastructure.
-        #
-        # This will have to do for the time being
-        reload(orm)
-        reload(file)
-        reload(preview)
-        reload(diskfile)
-        reload(createtables)
-        reload(dbtools)
+        try:
+            from gemini_obs_db import db_config as dbc
+
+            dbc.storage_root = abspath(dirname(self._db_path))
+            dbc.fits_dbname = basename(self._db_path)
+            dbc.db_path = self._db_path
+            dbc.database_url = 'sqlite:///' + fsc.db_path
+        except:
+            # handle older versions of GeminiCalMgr, which don't have or need dbc settings
+            # The reloading is kludgy, but Fits Storage was not designed to change
+            # databases on the fly, and we're reusing its infrastructure.
+            #
+            # This will have to do for the time being
+            reload(orm)
+            reload(file)
+            reload(preview)
+            reload(diskfile)
+            reload(createtables)
+            reload(dbtools)
 
         self.session = orm.sessionfactory()
 


### PR DESCRIPTION
The new GeminiCalMgr does support changing the DB location (as of now, made the change to support DRAGONS better).  I've modified the DRAGONS localmanager to initialize against the new GeminiCalMgr and it's separate FitsStorageDB (gemini_obs_db) dependency, but fall back to supporting a 2020-2 style GeminiCalMgr from FitsStorage local_calibs.