### PR TITLE
Refac/preserve order remove first frame

### DIFF
--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -212,10 +212,7 @@ class NearIR(PrimitivesBASE):
             if len(adinputs):
                 self.log.stdinfo("Removing earliest frame by timestamp.")
                 try:
-                    remove_ad = None
-                    for ad in adinputs:
-                        if remove_ad is None or ad.ut_datetime() < remove_ad.ut_datetime():
-                            remove_ad = ad
+                    remove_ad = self.sortInputs(adinputs, descriptor="ut_datetime")[0]
                     adinputs = [ad for ad in adinputs if ad != remove_ad]
                 except AttributeError:
                     self.log.warning("ut_datetime missing in inputs, unable to determine first frame.")

--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -10,13 +10,13 @@ from gempy.gemini import gemini_tools as gt
 
 from geminidr import PrimitivesBASE
 from geminidr.gemini.lookups import DQ_definitions as DQ
-from . import parameters_nearIR
+from . import parameters_nearIR, Bookkeeping
 
 from recipe_system.utils.decorators import parameter_override
 # ------------------------------------------------------------------------------
 
 @parameter_override
-class NearIR(PrimitivesBASE):
+class NearIR(Bookkeeping):
     tagset = None
 
     def __init__(self, adinputs, **kwargs):
@@ -210,12 +210,8 @@ class NearIR(PrimitivesBASE):
         """
         if params["remove_first"]:
             if len(adinputs):
-                self.log.stdinfo("Removing earliest frame by timestamp.")
-                try:
-                    remove_ad = self.sortInputs(adinputs, descriptor="ut_datetime")[0]
-                    adinputs = [ad for ad in adinputs if ad != remove_ad]
-                except AttributeError:
-                    self.log.warning("ut_datetime missing in inputs, unable to determine first frame.")
+                remove_ad = self.sortInputs(adinputs, descriptor="ut_datetime")[0]
+                adinputs = [ad for ad in adinputs if ad != remove_ad]
             else:
                 self.log.stdinfo("No frames, nothing to remove.")
         else:

--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -214,7 +214,7 @@ class NearIR(PrimitivesBASE):
                 try:
                     remove_ad = None
                     for ad in adinputs:
-                        if remove_ad is None or getattr(ad, "ut_datetime")() < getattr(remove_ad, "ut_datetime")():
+                        if remove_ad is None or ad.ut_datetime() < remove_ad.ut_datetime():
                             remove_ad = ad
                     adinputs = [ad for ad in adinputs if ad != remove_ad]
                 except AttributeError:

--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -209,8 +209,18 @@ class NearIR(PrimitivesBASE):
             a warning)
         """
         if params["remove_first"]:
-            adinputs = self.sortInputs(adinputs, descriptor="ut_datetime")
-            adinputs = self.rejectInputs(adinputs, at_start=1)
+            if len(adinputs):
+                self.log.stdinfo("Removing earliest frame by timestamp.")
+                try:
+                    remove_ad = None
+                    for ad in adinputs:
+                        if remove_ad is None or getattr(ad, "ut_datetime") < remove_ad.ut_datetime:
+                            remove_ad = ad
+                    adinputs = [ad for ad in adinputs if ad != remove_ad]
+                except AttributeError:
+                    self.log.warning("ut_datetime missing in inputs, unable to determine first frame.")
+            else:
+                self.log.stdinfo("No frames, nothing to remove.")
         else:
             self.log.warning("The first frame is not being removed: "
                              "data quality may suffer")

--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -214,7 +214,7 @@ class NearIR(PrimitivesBASE):
                 try:
                     remove_ad = None
                     for ad in adinputs:
-                        if remove_ad is None or getattr(ad, "ut_datetime") < remove_ad.ut_datetime:
+                        if remove_ad is None or getattr(ad, "ut_datetime")() < getattr(remove_ad, "ut_datetime")():
                             remove_ad = ad
                     adinputs = [ad for ad in adinputs if ad != remove_ad]
                 except AttributeError:

--- a/geminidr/core/tests/test_nearIR.py
+++ b/geminidr/core/tests/test_nearIR.py
@@ -14,14 +14,13 @@ from geminidr.core import primitives_nearIR
 
 def test_remove_first_frame():
     # ad input list maker functions
-    def make_ad(timestamp, add_timestamp=True):
+    def make_ad(timestamp):
         ad = create_zero_filled_fake_astrodata(100, 200)
-        if add_timestamp:
-            ad.ut_datetime = timestamp
+        ad.ut_datetime = timestamp
         return ad
 
-    def make_ads(timestamps, skip_idx=None):
-        return [make_ad(ts, skip_idx != idx) for idx, ts in enumerate(timestamps)]
+    def make_ads(timestamps):
+        return [make_ad(ts) for idx, ts in enumerate(timestamps)]
 
     jan = datetime(year=2021, month=1, day=1)
     feb = datetime(year=2021, month=2, day=1)
@@ -50,15 +49,6 @@ def test_remove_first_frame():
     assert len(ad_out) == 2
     assert ad_out[0] == ad_in[0]
     assert ad_out[1] == ad_in[2]
-
-    # missing ut_datetime
-    _p = primitives_nearIR.NearIR([])
-    ad_in = make_ads([jan, feb, mar], skip_idx=1)
-    ad_out = _p.removeFirstFrame(ad_in)
-    assert len(ad_out) == 3
-    assert ad_out[0] == ad_in[0]
-    assert ad_out[1] == ad_in[1]
-    assert ad_out[2] == ad_in[2]
 
     # duplicate ut_datetime
     _p = primitives_nearIR.NearIR([])

--- a/geminidr/core/tests/test_nearIR.py
+++ b/geminidr/core/tests/test_nearIR.py
@@ -1,0 +1,74 @@
+"""
+Tests applied to primitives_nearIR.py
+"""
+
+from datetime import datetime
+
+import pytest
+
+from geminidr.core.tests.test_spect import create_zero_filled_fake_astrodata
+from geminidr.core import primitives_nearIR
+
+# -- Tests --------------------------------------------------------------------
+
+
+def test_remove_first_frame():
+    # ad input list maker functions
+    def make_ad(timestamp, add_timestamp=True):
+        ad = create_zero_filled_fake_astrodata(100, 200)
+        if add_timestamp:
+            ad.ut_datetime = timestamp
+        return ad
+
+    def make_ads(timestamps, skip_idx=None):
+        return [make_ad(ts, skip_idx != idx) for idx, ts in enumerate(timestamps)]
+
+    jan = datetime(year=2021, month=1, day=1)
+    feb = datetime(year=2021, month=2, day=1)
+    mar = datetime(year=2021, month=3, day=1)
+
+    # Simple case, in order
+    _p = primitives_nearIR.NearIR([])
+    ad_in = make_ads([jan, feb, mar])
+    ad_out = _p.removeFirstFrame(ad_in)
+    assert len(ad_out) == 2
+    assert ad_out[0] == ad_in[1]
+    assert ad_out[1] == ad_in[2]
+
+    # reverse order
+    _p = primitives_nearIR.NearIR([])
+    ad_in = make_ads([mar, feb, jan])
+    ad_out = _p.removeFirstFrame(ad_in)
+    assert len(ad_out) == 2
+    assert ad_out[0] == ad_in[1]
+    assert ad_out[1] == ad_in[0]
+
+    # jan in middle
+    _p = primitives_nearIR.NearIR([])
+    ad_in = make_ads([feb, jan, mar])
+    ad_out = _p.removeFirstFrame(ad_in)
+    assert len(ad_out) == 2
+    assert ad_out[0] == ad_in[0]
+    assert ad_out[1] == ad_in[2]
+
+    # missing ut_datetime
+    _p = primitives_nearIR.NearIR([])
+    ad_in = make_ads([jan, feb, mar], skip_idx=1)
+    ad_out = _p.removeFirstFrame(ad_in)
+    assert len(ad_out) == 3
+    assert ad_out[0] == ad_in[0]
+    assert ad_out[1] == ad_in[1]
+    assert ad_out[2] == ad_in[2]
+
+    # duplicate ut_datetime
+    _p = primitives_nearIR.NearIR([])
+    ad_in = make_ads([feb, jan, jan, mar])
+    ad_out = _p.removeFirstFrame(ad_in)
+    assert len(ad_out) == 3
+    assert ad_out[0] == ad_in[1]
+    assert ad_out[1] == ad_in[0]
+    assert ad_out[2] == ad_in[3]
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/geminidr/core/tests/test_nearIR.py
+++ b/geminidr/core/tests/test_nearIR.py
@@ -40,8 +40,8 @@ def test_remove_first_frame():
     ad_in = make_ads([mar, feb, jan])
     ad_out = _p.removeFirstFrame(ad_in)
     assert len(ad_out) == 2
-    assert ad_out[0] == ad_in[1]
-    assert ad_out[1] == ad_in[0]
+    assert ad_out[0] == ad_in[0]
+    assert ad_out[1] == ad_in[1]
 
     # jan in middle
     _p = primitives_nearIR.NearIR([])
@@ -65,8 +65,8 @@ def test_remove_first_frame():
     ad_in = make_ads([feb, jan, jan, mar])
     ad_out = _p.removeFirstFrame(ad_in)
     assert len(ad_out) == 3
-    assert ad_out[0] == ad_in[1]
-    assert ad_out[1] == ad_in[0]
+    assert ad_out[0] == ad_in[0]
+    assert ad_out[1] == ad_in[2]
     assert ad_out[2] == ad_in[3]
 
 


### PR DESCRIPTION
Dropping earliest by ut_datetime, but preserving order of the remaning