### PR TITLE
refactored tab content handling to fix layout issues

### DIFF
--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -1384,7 +1384,11 @@ class TabsTurboInjector:
             The new selection
         """
         if old != new:
-            self.tabs.tabs[old].child.children[0] = self.tab_dummy_children[old]
+            def clear_old_tab():
+                self.tabs.tabs[old].child.children[0] = self.tab_dummy_children[old]
+            # clear the old tab via an event on the UI loop
+            # we don't want to do it right now - wait until the tab change has happened
+            do_later(clear_old_tab)
             self.tabs.tabs[new].child.children[0] = self.tab_children[new]
 
 


### PR DESCRIPTION
Modifying tabs in bokeh while they are visible was causing issues in the latest version.  I modified the TurboTabsInjector logic to postpone clearing the old tab onto the event loop so it happens after the tab is removed from view.  There is still a layout delay bringing in the new tab contents but that seems unavoidable as there's no kind of "pre-event hook" for tab selection.