### PR TITLE
Enh/gain readnoise propagation

### DIFF
--- a/gemini_instruments/f2/adclass.py
+++ b/gemini_instruments/f2/adclass.py
@@ -3,7 +3,7 @@ import math
 
 from astrodata import (astro_data_tag, TagSet, astro_data_descriptor,
                        returns_list, Section)
-from ..gemini import AstroDataGemini
+from ..gemini import AstroDataGemini, use_keyword_if_prepared
 from .lookup import array_properties, nominal_zeropoints
 
 from ..common import build_group_id
@@ -384,6 +384,7 @@ class AstroDataF2(AstroDataGemini):
         return '&'.join(filter[:2])
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def gain(self):
         """
@@ -570,6 +571,7 @@ class AstroDataF2(AstroDataGemini):
         return None if lnrs is None else str(lnrs)
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def read_noise(self):
         """
@@ -580,7 +582,6 @@ class AstroDataF2(AstroDataGemini):
         float
             read noise
         """
-        # Element [0] gives the read noise
         return getattr(array_properties.get(self.read_mode(), None),
                        'readnoise', None)
 

--- a/gemini_instruments/gemini/__init__.py
+++ b/gemini_instruments/gemini/__init__.py
@@ -1,7 +1,8 @@
-__all__ = ['AstroDataGemini', 'addInstrumentFilterWavelengths']
+__all__ = ['AstroDataGemini', 'addInstrumentFilterWavelengths',
+           'use_keyword_if_prepared']
 
 from astrodata import factory
-from .adclass import AstroDataGemini
+from .adclass import AstroDataGemini, use_keyword_if_prepared
 from .lookup import filter_wavelengths
 
 def addInstrumentFilterWavelengths(instrument, wl):

--- a/gemini_instruments/gemini/adclass.py
+++ b/gemini_instruments/gemini/adclass.py
@@ -106,6 +106,17 @@ gemini_keyword_names = dict(
     telescope_y_offset = 'YOFFSET',
 )
 
+
+def use_keyword_if_prepared(fn):
+    def gn(self):
+        if "PREPARED" in self.tags:
+            try:
+                return self.hdr[self._keyword_for(fn.__name__)]
+            except (KeyError, AttributeError):
+                pass
+        return fn(self)
+    return gn
+
 # ------------------------------------------------------------------------------
 class AstroDataGemini(AstroData):
     __keyword_dict = gemini_keyword_names

--- a/gemini_instruments/gmos/adclass.py
+++ b/gemini_instruments/gmos/adclass.py
@@ -8,7 +8,7 @@ from astrodata import (astro_data_tag, astro_data_descriptor, returns_list,
 from .pixel_functions import get_bias_level
 from . import lookup
 from .. import gmu
-from ..gemini import AstroDataGemini
+from ..gemini import AstroDataGemini, use_keyword_if_prepared
 
 
 class AstroDataGmos(AstroDataGemini):
@@ -567,6 +567,7 @@ class AstroDataGmos(AstroDataGemini):
         return 'Imaging' if mask == 'None' else mask
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def gain(self):
         """
@@ -578,10 +579,6 @@ class AstroDataGmos(AstroDataGemini):
             Gains used for the observation
 
         """
-        # If the file has been prepared, we trust the header keywords
-        if 'PREPARED' in self.tags:
-            return self.hdr.get(self._keyword_for('gain'))
-
         # Get the correct dict of gain values
         ut_date = self.ut_date()
         if ut_date is None:
@@ -917,6 +914,7 @@ class AstroDataGmos(AstroDataGemini):
         return mode_dict.get(mode_key)
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def read_noise(self):
         """

--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -3,7 +3,7 @@ import re
 
 from astrodata import astro_data_tag, astro_data_descriptor, TagSet, returns_list
 
-from ..gemini import AstroDataGemini
+from ..gemini import AstroDataGemini, use_keyword_if_prepared
 from ..common import build_group_id
 
 from .lookup import detector_properties, nominal_zeropoints, read_modes
@@ -266,6 +266,7 @@ class AstroDataGnirs(AstroDataGemini):
         return fpm
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def gain(self):
         """
@@ -503,6 +504,7 @@ class AstroDataGnirs(AstroDataGemini):
                               "Unknown")
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def read_noise(self):
         """

--- a/gemini_instruments/gsaoi/adclass.py
+++ b/gemini_instruments/gsaoi/adclass.py
@@ -1,7 +1,7 @@
 import math
 
 from astrodata import astro_data_tag, TagSet, astro_data_descriptor, returns_list
-from ..gemini import AstroDataGemini
+from ..gemini import AstroDataGemini, use_keyword_if_prepared
 from .. import gmu
 from ..common import build_group_id
 from . import lookup
@@ -111,6 +111,7 @@ class AstroDataGsaoi(AstroDataGemini):
                                      output_units)
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def gain(self):
         """
@@ -255,6 +256,8 @@ class AstroDataGsaoi(AstroDataGemini):
             return [f * s if f and s else None
                     for f, s in zip(fraction, sat_level)]
 
+    @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def read_noise(self):
         """

--- a/gemini_instruments/niri/adclass.py
+++ b/gemini_instruments/niri/adclass.py
@@ -1,5 +1,5 @@
 from astrodata import astro_data_tag, TagSet, astro_data_descriptor, returns_list
-from ..gemini import AstroDataGemini
+from ..gemini import AstroDataGemini, use_keyword_if_prepared
 import math
 
 from . import lookup
@@ -311,6 +311,7 @@ class AstroDataNiri(AstroDataGemini):
         return '&'.join(filters)
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def gain(self):
         """
@@ -466,6 +467,7 @@ class AstroDataNiri(AstroDataGemini):
             return 'Unknown'
 
     @returns_list
+    @use_keyword_if_prepared
     @astro_data_descriptor
     def read_noise(self):
         """

--- a/geminidr/core/primitives_preprocess.py
+++ b/geminidr/core/primitives_preprocess.py
@@ -114,6 +114,10 @@ class Preprocess(PrimitivesBASE):
             # Update the headers of the AstroData Object. The pixel data now
             # has units of electrons so update the physical units keyword.
             ad.hdr.set('BUNIT', 'electron', self.keyword_comments['BUNIT'])
+            try:
+                ad.hdr.set(ad._keyword_for("gain"), 1.)
+            except AttributeError:  # No keyword for "gain"
+                pass
             gt.mark_history(ad, primname=self.myself(), keyword=timestamp_key)
             ad.update_filename(suffix=suffix,  strip=True)
 

--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -292,8 +292,8 @@ class Stack(PrimitivesBASE):
                 gains = [g[index] for g in gain_list]
                 # If all inputs have the same gain, the output will also have
                 # this gain, and since the header has been copied, we don't
-                # need to do anything!
-                if len(set(gains)) > 1:
+                # need to do anything! (Can't use set() if gains are lists.)
+                if not all(g == gains[0] for g in gains):
                     log.warning("Not all inputs have the same gain.")
                     try:
                         output_gain = num_img / np.sum([1/g for g in gains])

--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -114,6 +114,10 @@ class Stack(PrimitivesBASE):
         AssertError
             If any of the `.read_noise()` descriptors is None.
         """
+        def flatten(*args):
+            return (el for item in args for el in (
+                flatten(*item) if isinstance(item, (list, tuple)) else (item,)))
+
         log = self.log
         log.debug(gt.log_message("primitive", self.myself(), "starting"))
         timestamp_key = self.timestamp_keys["stackFrames"]
@@ -153,25 +157,16 @@ class Stack(PrimitivesBASE):
 
         # We will determine the average gain from the input AstroData
         # objects and add in quadrature the read noise
-        gains = [ad.gain() for ad in adinputs]
-        read_noises = [ad.read_noise() for ad in adinputs]
+        gain_list = [ad.gain() for ad in adinputs]
+        rn_list = [ad.read_noise() for ad in adinputs]
 
         # Determine whether we can construct these averages
-        process_gain = all(g is not None and not isinstance(g, list)
-                           for gain in gains for g in gain)
-        process_rn = all(rn is not None and not isinstance(rn, list)
-                         for read_noise in read_noises for rn in read_noise)
+        process_gain = not any(g is None for g in flatten(gain_list))
+        process_rn = not any(rn is None for rn in flatten(rn_list))
 
         # Compute gain and read noise of final stacked images
         num_img = len(adinputs)
         num_ext = len(adinputs[0])
-        if process_gain:
-            gain_list = [np.mean([gain[i] for gain in gains])
-                         for i in range(num_ext)]
-        if process_rn:
-            read_noise_list = [np.sqrt(np.sum([rn[i]*rn[i]for rn in read_noises])) / num_img
-                                         for i in range(num_ext)]
-
         zero_offsets = np.zeros((num_ext, num_img), dtype=np.float32)
         scale_factors = np.ones_like(zero_offsets)
 
@@ -265,9 +260,9 @@ class Stack(PrimitivesBASE):
                 status += " Applying offsets."
                 numbers = zfactors
             log.stdinfo(status)
-            if ((scale or zero) and (index == 0 or separate_ext)):
+            if (scale or zero) and (index == 0 or separate_ext):
                 for ad, value in zip(adinputs, numbers):
-                    log.stdinfo("{:40s}{:10.3f}".format(ad.filename, value))
+                    log.stdinfo(f"{ad.filename:40s}{value:10.3f}")
 
             shape = adinputs[0][index].nddata.shape
             if memory is None:
@@ -292,6 +287,28 @@ class Stack(PrimitivesBASE):
                                 with_mask=with_mask,
                                 save_rejection_map=save_rejection_map)
             ad_out.append(result)
+
+            if process_gain:
+                gains = [g[index] for g in gain_list]
+                # If all inputs have the same gain, the output will also have
+                # this gain, and since the header has been copied, we don't
+                # need to do anything!
+                if len(set(gains)) > 1:
+                    log.warning("Not all inputs have the same gain.")
+                    try:
+                        output_gain = num_img / np.sum([1/g for g in gains])
+                    except TypeError:
+                        pass
+                    else:
+                        ad_out[-1].hdr[ad_out._keyword_for("gain")] = output_gain
+
+            if process_rn:
+                # Output gets the rms value of the inputs
+                rns = [rn[index] for rn in rn_list]
+                output_rn = np.sqrt(np.mean([np.square(np.asarray(rn).mean())
+                                             for rn in rns]))
+                ad_out[-1].hdr[ad_out._keyword_for("read_noise")] = output_rn
+
             log.stdinfo("")
 
         # Propagate REFCAT as the union of all input REFCATs
@@ -314,18 +331,6 @@ class Stack(PrimitivesBASE):
             pass
         else:
             ad_out.phu.set(airmass_kw, mean_airmass, "Mean airmass for the exposure")
-
-        # Set GAIN to the average of input gains. Set the RDNOISE to the
-        # sum in quadrature of the input read noises.
-        if process_gain:
-            for ext, gain in zip(ad_out, gain_list):
-                ext.hdr.set('GAIN', gain, self.keyword_comments['GAIN'])
-            ad_out.phu.set('GAIN', gain_list[0], self.keyword_comments['GAIN'])
-
-        if process_rn:
-            for ext, rn in zip(ad_out, read_noise_list):
-                ext.hdr.set('RDNOISE', rn, self.keyword_comments['RDNOISE'])
-            ad_out.phu.set('RDNOISE', read_noise_list[0], self.keyword_comments['RDNOISE'])
 
         # Add suffix to datalabel to distinguish from the reference frame
         if sfx[0] == '_':

--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -161,8 +161,8 @@ class Stack(PrimitivesBASE):
         rn_list = [ad.read_noise() for ad in adinputs]
 
         # Determine whether we can construct these averages
-        process_gain = not any(g is None for g in flatten(gain_list))
-        process_rn = not any(rn is None for rn in flatten(rn_list))
+        process_gain = not None in flatten(gain_list)
+        process_rn = not None in flatten(rn_list)
 
         # Compute gain and read noise of final stacked images
         num_img = len(adinputs)

--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -10,6 +10,7 @@ import urllib.request
 
 from copy import deepcopy
 from importlib import import_module
+from contextlib import suppress
 
 from gempy.utils import logutils
 from gempy.gemini import gemini_tools as gt
@@ -343,7 +344,8 @@ class Visualize(PrimitivesBASE):
 
             # Update read noise: we assume that all the regions represented
             # by a value have the same number of pixels, so the mean is OK
-            ad_out[0].hdr[ad._keyword_for('read_noise')] = np.mean(ad.read_noise())
+            with suppress(TypeError):  # some NoneTypes in read_noise
+                ad_out[0].hdr[ad._keyword_for('read_noise')] = np.mean(ad.read_noise())
             ad_out.orig_filename = ad.filename
             gt.mark_history(ad_out, primname=self.myself(), keyword=timestamp_key)
             ad_out.update_filename(suffix=suffix, strip=True)
@@ -498,7 +500,8 @@ class Visualize(PrimitivesBASE):
                     else:
                         ad_out.append(transform.resample_from_wcs(
                             ad[exts], "tile",attributes=attributes, process_objcat=True)[0])
-                    ad_out[-1].hdr[kw_readnoise] = np.mean(read_noise_list)
+                    with suppress(TypeError):
+                        ad_out[-1].hdr[kw_readnoise] = np.mean(read_noise_list)
                     read_noise_list = []
 
                 i += 1
@@ -507,7 +510,8 @@ class Visualize(PrimitivesBASE):
             if tile_all:
                 ad_out = transform.resample_from_wcs(ad, "tile", attributes=attributes,
                                                      process_objcat=True)
-                ad_out[0].hdr[kw_readnoise] = np.mean(read_noise_list)
+                with suppress(TypeError):
+                    ad_out[0].hdr[kw_readnoise] = np.mean(read_noise_list)
 
             gt.mark_history(ad_out, primname=self.myself(), keyword=timestamp_key)
             ad_out.orig_filename = ad.filename

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -100,8 +100,8 @@ def test_rejmap(niri_adinputs):
 
 
 def test_stacking_without_gain_or_readnoise(f2_adinputs):
-    """We use F2 since it doesn't use a LUT to return values for the
-    gain() and read_noise() descriptors"""
+    """We use F2 since our fake data return None for gain and read_noise,
+    due to the absence of the LNRS keyword"""
     p = F2Image(f2_adinputs)
     assert f2_adinputs[0].gain() == [None]
     assert f2_adinputs[0].read_noise() == [None]

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -41,8 +41,8 @@ def niri_adinputs():
     return adinputs
 
 
-@pytest.mark.skip("bquint - Investigate this test")
 def test_error_only_one_file(niri_adinputs, caplog):
+    caplog.set_level(20)  # INFO
     # With only one file
     p = NIRIImage(niri_adinputs[1:])
     p.stackFrames()

--- a/geminidr/gnirs/primitives_gnirs.py
+++ b/geminidr/gnirs/primitives_gnirs.py
@@ -79,7 +79,7 @@ class GNIRS(Gemini, NearIR):
 
             if 'SPECT' in ad.tags:
                 kw = ad._keyword_for('dispersion_axis')
-                self.hdr.set(kw, 2, self.keyword_comments(kw))
+                ad.hdr.set(kw, 2, self.keyword_comments[kw])
 
             # Adding the WCS information to the pixel data header, since for
             # GNIRS images at least, it may be only in the PHU

--- a/geminidr/gsaoi/primitives_gsaoi.py
+++ b/geminidr/gsaoi/primitives_gsaoi.py
@@ -63,9 +63,7 @@ class GSAOI(Gemini, NearIR):
 
             for desc in ('read_noise', 'gain', 'non_linear_level',
                          'saturation_level'):
-
                 kw = ad._keyword_for(desc)
-
                 for ext, value in zip(ad, getattr(ad, desc)()):
                     ext.hdr.set(kw, value, self.keyword_comments[kw])
 


### PR DESCRIPTION
This does the following: 
- sets the gain to 1 after ADUToElectrons
- warns if an image is being mosaicked/tiled with different gains on different extensions (using the tiling is being called by "display"), but sets the output gain to the mean of the input gains
- sets the output read noise when tiling/mosaicking to the mean of the input read noises
- warns if the gains are different when stacking images, but sets the output gain to the harmonic mean of the input gains
- sets the output read noise to the mean of the input read noises when stacking

In order to "set" the gain or read noise, there is a new decorator, "use_value_if_prepared", which will cause a descriptor to simply return the keyword value from the header (if it exists), rather than execute the code in the body of the descriptor. This is required because some instrument descriptors simply read a LUT and so the value returned is immutable.