### PR TITLE
Combine darks with very different exp time

### DIFF
--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -257,7 +257,7 @@ class NearIR(PrimitivesBASE):
         log = self.log
         log.debug(gt.log_message("primitive", self.myself(), "starting"))
 
-        if not all(dark.exposure_time() == adinputs[0].exposure_time()
+        if not all(round(dark.exposure_time(),2) == round(adinputs[0].exposure_time(),2)
                    for dark in adinputs[1:]):
                 raise OSError("Darks are not of equal exposure time")
 


### PR DESCRIPTION
The current version doesn't allow darks with e.g., 60.001 and 60.002 sec exposure times to be combined. This proposed change rounds the exposure time check to 2 decimal points to allow these insignificant exp time differences to be ignored.