### PR TITLE
user parameter validation to check for unrecognized parameters (or pr…

### DIFF
--- a/geminidr/__init__.py
+++ b/geminidr/__init__.py
@@ -227,8 +227,9 @@ class PrimitivesBASE:
         :raises: :class:~recipe_system.reduction.coreReduce.UnrecognizedParameterException: \
             when a user parameter uses an unrecognized primitive or parameter name
         """
-        if self.user_params and (PrimitivesBASE._validated_user_parms is None
-                                 or PrimitivesBASE._validated_user_parms == self.user_parms):
+        if hasattr(self, 'user_params') and self.user_params 
+                and (PrimitivesBASE._validated_user_parms is None
+                     or PrimitivesBASE._validated_user_parms == self.user_parms):
             for key in self.user_params.keys():
                 primitive = None
                 if ':' in key:

--- a/geminidr/__init__.py
+++ b/geminidr/__init__.py
@@ -258,7 +258,7 @@ class PrimitivesBASE:
             return msg
 
         if self.user_params and (PrimitivesBASE._validated_user_parms is None
-                                 or PrimitivesBASE._validated_user_parms == self.user_params):
+                                 or PrimitivesBASE._validated_user_parms != self.user_params):
             for key in self.user_params.keys():
                 primitive = None
                 if ':' in key:

--- a/geminidr/__init__.py
+++ b/geminidr/__init__.py
@@ -30,6 +30,7 @@ from astropy.io.fits.verify import VerifyWarning
 
 # new system imports - 10-06-2016 kra
 # NOTE: imports of these and other tables will be moving around ...
+from gempy.utils.soundex import soundex
 from recipe_system.reduction.coreReduce import UnrecognizedParameterException
 from .gemini.lookups import keyword_comments
 from .gemini.lookups import timestamp_keywords
@@ -254,6 +255,9 @@ class PrimitivesBASE:
             if name in valid_names:
                 return None
             alternative_names = [n for n in valid_names if n.upper() == name.upper()]
+            if alternative_names:
+                return alternative_names
+            alternative_names = [n for n in valid_names if soundex(n) == soundex(name)]
             return alternative_names
 
         for key in self.user_params.keys():

--- a/geminidr/__init__.py
+++ b/geminidr/__init__.py
@@ -240,9 +240,8 @@ class PrimitivesBASE:
         :raises: :class:~recipe_system.reduction.coreReduce.UnrecognizedParameterException: \
             when a user parameter uses an unrecognized primitive or parameter name
         """
-        if hasattr(self, 'user_params') and self.user_params \
-                and (PrimitivesBASE._validated_user_parms is None \
-                     or PrimitivesBASE._validated_user_parms == self.user_parms):
+        if self.user_params and (PrimitivesBASE._validated_user_parms is None
+                                 or PrimitivesBASE._validated_user_parms == self.user_params):
             for key in self.user_params.keys():
                 primitive = None
                 if ':' in key:

--- a/geminidr/core/primitives_bookkeeping.py
+++ b/geminidr/core/primitives_bookkeeping.py
@@ -25,8 +25,8 @@ class Bookkeeping(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_bookkeeping)
 
     def addToList(self, adinputs=None, purpose=None):

--- a/geminidr/core/primitives_calibdb.py
+++ b/geminidr/core/primitives_calibdb.py
@@ -21,8 +21,8 @@ class CalibDB(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_calibdb)
         self._not_found = "Calibration not found for {}"
 

--- a/geminidr/core/primitives_ccd.py
+++ b/geminidr/core/primitives_ccd.py
@@ -26,8 +26,8 @@ class CCD(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_ccd)
 
     def biasCorrect(self, adinputs=None, suffix=None, bias=None, do_cal=None):

--- a/geminidr/core/primitives_image.py
+++ b/geminidr/core/primitives_image.py
@@ -29,8 +29,8 @@ class Image(Preprocess, Register, Resample):
     """
     tagset = {"IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_image)
 
     def fringeCorrect(self, adinputs=None, **params):

--- a/geminidr/core/primitives_nearIR.py
+++ b/geminidr/core/primitives_nearIR.py
@@ -19,8 +19,8 @@ from recipe_system.utils.decorators import parameter_override
 class NearIR(Bookkeeping):
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_nearIR)
 
     def addLatencyToDQ(self, adinputs=None, **params):

--- a/geminidr/core/primitives_photometry.py
+++ b/geminidr/core/primitives_photometry.py
@@ -28,8 +28,8 @@ class Photometry(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_photometry)
 
     def addReferenceCatalog(self, adinputs=None, **params):

--- a/geminidr/core/primitives_preprocess.py
+++ b/geminidr/core/primitives_preprocess.py
@@ -37,8 +37,8 @@ class Preprocess(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_preprocess)
 
     def addObjectMaskToDQ(self, adinputs=None, suffix=None):

--- a/geminidr/core/primitives_register.py
+++ b/geminidr/core/primitives_register.py
@@ -31,8 +31,8 @@ class Register(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_register)
 
     def adjustWCSToReference(self, adinputs=None, **params):

--- a/geminidr/core/primitives_resample.py
+++ b/geminidr/core/primitives_resample.py
@@ -33,8 +33,8 @@ class Resample(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_resample)
 
     def resampleToCommonFrame(self, adinputs=None, **params):

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -71,8 +71,8 @@ class Spect(PrimitivesBASE):
     """
     tagset = {"GEMINI", "SPECT"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_spect)
 
     def adjustWCSToReference(self, adinputs=None, **params):

--- a/geminidr/core/primitives_stack.py
+++ b/geminidr/core/primitives_stack.py
@@ -26,8 +26,8 @@ class Stack(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_stack)
 
     def stackFlats(self, adinputs=None, **params):

--- a/geminidr/core/primitives_standardize.py
+++ b/geminidr/core/primitives_standardize.py
@@ -28,8 +28,8 @@ class Standardize(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_standardize)
 
     def addDQ(self, adinputs=None, **params):

--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -40,8 +40,8 @@ class Visualize(PrimitivesBASE):
     """
     tagset = None
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_visualize)
 
     def display(self, adinputs=None, **params):

--- a/geminidr/f2/primitives_f2.py
+++ b/geminidr/f2/primitives_f2.py
@@ -24,9 +24,9 @@ class F2(Gemini, NearIR):
     """
     tagset = {"GEMINI", "F2"}
 
-    def __init__(self, adinputs, **kwargs):
+    def _initialize(self, adinputs, **kwargs):
         self.inst_lookups = 'geminidr.f2.lookups'
-        super().__init__(adinputs, **kwargs)
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_f2)
 
     def standardizeInstrumentHeaders(self, adinputs=None, **params):

--- a/geminidr/f2/primitives_f2_image.py
+++ b/geminidr/f2/primitives_f2_image.py
@@ -20,8 +20,8 @@ class F2Image(F2, Image, Photometry):
     """
     tagset = {"GEMINI", "F2", "IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_f2_image)
 
     def makeLampFlat(self, adinputs=None, **params):

--- a/geminidr/f2/primitives_f2_spect.py
+++ b/geminidr/f2/primitives_f2_spect.py
@@ -23,8 +23,8 @@ class F2Spect(F2, Spect):
     """
     tagset = {"GEMINI", "F2", "SPECT"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_f2_spect)
 
     def _get_linelist_filename(self, ext, cenwave, dw):

--- a/geminidr/gemini/primitives_gemini.py
+++ b/geminidr/gemini/primitives_gemini.py
@@ -22,8 +22,8 @@ class Gemini(Standardize, Bookkeeping, Preprocess, Visualize, Stack, QA,
     """
     tagset = {"GEMINI"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gemini)
 
     def addMDF(self, adinputs=None, suffix=None, mdf=None):

--- a/geminidr/gemini/primitives_qa.py
+++ b/geminidr/gemini/primitives_qa.py
@@ -33,8 +33,8 @@ class QA(PrimitivesBASE):
     """
     tagset = {"GEMINI"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_qa)
 
     def measureBG(self, adinputs=None, **params):

--- a/geminidr/gmos/primitives_gmos.py
+++ b/geminidr/gmos/primitives_gmos.py
@@ -27,9 +27,9 @@ class GMOS(Gemini, CCD):
     """
     tagset = {"GEMINI", "GMOS"}
 
-    def __init__(self, adinputs, **kwargs):
+    def _initialize(self, adinputs, **kwargs):
         self.inst_lookups = 'geminidr.gmos.lookups'
-        super().__init__(adinputs, **kwargs)
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos)
 
     def standardizeInstrumentHeaders(self, adinputs=None, suffix=None):

--- a/geminidr/gmos/primitives_gmos_ifu.py
+++ b/geminidr/gmos/primitives_gmos_ifu.py
@@ -16,6 +16,6 @@ class GMOSIFU(GMOSSpect, GMOSNodAndShuffle):
     """
     tagset = {"GEMINI", "GMOS", "SPECT", "IFU"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_ifu)

--- a/geminidr/gmos/primitives_gmos_image.py
+++ b/geminidr/gmos/primitives_gmos_image.py
@@ -35,8 +35,8 @@ class GMOSImage(GMOS, Image, Photometry):
     """
     tagset = {"GEMINI", "GMOS", "IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_image)
 
     def addOIWFSToDQ(self, adinputs=None, **params):

--- a/geminidr/gmos/primitives_gmos_longslit.py
+++ b/geminidr/gmos/primitives_gmos_longslit.py
@@ -71,8 +71,8 @@ class GMOSClassicLongslit(GMOSSpect):
     the primitives from the level above
     """
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_longslit)
 
     def addIllumMaskToDQ(self, adinputs=None, suffix=None, illum_mask=None,
@@ -1023,6 +1023,6 @@ def _split_mosaic_into_extensions(ref_ad, mos_ad, border_size=0):
 
 @parameter_override
 class GMOSNSLongslit(GMOSClassicLongslit, GMOSNodAndShuffle):
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_longslit)

--- a/geminidr/gmos/primitives_gmos_mos.py
+++ b/geminidr/gmos/primitives_gmos_mos.py
@@ -18,6 +18,6 @@ class GMOSMOS(GMOSSpect, GMOSNodAndShuffle):
     """
     tagset = {"GEMINI", "GMOS", "SPECT", "MOS"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_mos)

--- a/geminidr/gmos/primitives_gmos_nodandshuffle.py
+++ b/geminidr/gmos/primitives_gmos_nodandshuffle.py
@@ -33,8 +33,8 @@ class GMOSNodAndShuffle(GMOS):
     """
     tagset = set()
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_nodandshuffle)
 
     def combineNodAndShuffleBeams(self, adinputs=None, **params):

--- a/geminidr/gmos/primitives_gmos_spect.py
+++ b/geminidr/gmos/primitives_gmos_spect.py
@@ -144,8 +144,8 @@ class GMOSSpect(Spect, GMOS):
     """
     tagset = {"GEMINI", "GMOS", "SPECT"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gmos_spect)
 
     def QECorrect(self, adinputs=None, **params):

--- a/geminidr/gnirs/primitives_gnirs.py
+++ b/geminidr/gnirs/primitives_gnirs.py
@@ -21,9 +21,9 @@ class GNIRS(Gemini, NearIR):
     """
     tagset = {"GEMINI", "GNIRS"}
 
-    def __init__(self, adinputs, **kwargs):
+    def _initialize(self, adinputs, **kwargs):
         self.inst_lookups = 'geminidr.gnirs.lookups'
-        super().__init__(adinputs, **kwargs)
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gnirs)
 
     def standardizeInstrumentHeaders(self, adinputs=None, suffix=None):

--- a/geminidr/gnirs/primitives_gnirs_image.py
+++ b/geminidr/gnirs/primitives_gnirs_image.py
@@ -28,8 +28,8 @@ class GNIRSImage(GNIRS, Image, Photometry):
     """
     tagset = {"GEMINI", "GNIRS", "IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gnirs_image)
 
     def addIllumMaskToDQ(self, adinputs=None, **params):

--- a/geminidr/gsaoi/primitives_gsaoi.py
+++ b/geminidr/gsaoi/primitives_gsaoi.py
@@ -23,9 +23,9 @@ class GSAOI(Gemini, NearIR):
     """
     tagset = {"GEMINI", "GSAOI"}
 
-    def __init__(self, adinputs, **kwargs):
+    def _initialize(self, adinputs, **kwargs):
         self.inst_lookups = 'geminidr.gsaoi.lookups'
-        super().__init__(adinputs, **kwargs)
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gsaoi)
 
     def standardizeInstrumentHeaders(self, adinputs=None, suffix=None):

--- a/geminidr/gsaoi/primitives_gsaoi_image.py
+++ b/geminidr/gsaoi/primitives_gsaoi_image.py
@@ -39,8 +39,8 @@ class GSAOIImage(GSAOI, Image, Photometry):
     """
     tagset = {"GEMINI", "GSAOI", "IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_gsaoi_image)
 
     def adjustWCSToReference(self, adinputs=None, **params):

--- a/geminidr/niri/primitives_niri.py
+++ b/geminidr/niri/primitives_niri.py
@@ -23,9 +23,9 @@ class NIRI(Gemini, NearIR):
     """
     tagset = {"GEMINI", "NIRI"}
 
-    def __init__(self, adinputs, **kwargs):
+    def _initialize(self, adinputs, **kwargs):
         self.inst_lookups = 'geminidr.niri.lookups'
-        super().__init__(adinputs, **kwargs)
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_niri)
 
     def nonlinearityCorrect(self, adinputs=None, suffix=None):

--- a/geminidr/niri/primitives_niri_image.py
+++ b/geminidr/niri/primitives_niri_image.py
@@ -27,8 +27,8 @@ class NIRIImage(NIRI, Image, Photometry):
     """
     tagset = {"GEMINI", "NIRI", "IMAGE"}
 
-    def __init__(self, adinputs, **kwargs):
-        super().__init__(adinputs, **kwargs)
+    def _initialize(self, adinputs, **kwargs):
+        super()._initialize(adinputs, **kwargs)
         self._param_update(parameters_niri_image)
 
     def removePatternNoise(self, adinputs=None, **params):

--- a/geminidr/tests/test_geminidr.py
+++ b/geminidr/tests/test_geminidr.py
@@ -11,11 +11,11 @@ import gemini_instruments  # needed to initialize instrument support
                          [
                              ([('nteractive', True)], 'Parameter nteractive not recognized'),
                              ([('calculateSensitivity:nteractive', True)], 'Parameter nteractive not recognized'),
-                             ([('alculateSensitivity:interactive', True)], 'Primitive alculateSensitivity not found'),
+                             ([('alculateSensitivity:interactive', True)], 'Primitive alculateSensitivity not recognized'),
                              ([('calculateSensitivity:Interactive', True)],
-                              'Parameter Interactive not found, did you mean interactive?'),
+                              'Parameter Interactive not recognized, did you mean interactive?'),
                              ([('CalculateSensitivity:interactive', True)],
-                              'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
+                              'Primitive CalculateSensitivity not recognized, did you mean calculateSensitivity?'),
                              ([('calculateSensitivity:interactive:pickles', True)],
                               'Expecting parameter or primitive:parameter in -p user parameters')
                          ])

--- a/geminidr/tests/test_geminidr.py
+++ b/geminidr/tests/test_geminidr.py
@@ -1,4 +1,6 @@
 import pytest
+
+import geminidr
 from astrodata.testing import download_from_archive
 from geminidr.gmos.primitives_gmos_longslit import GMOSLongslit
 from recipe_system.reduction.coreReduce import UnrecognizedParameterException
@@ -27,3 +29,35 @@ def test_unrecognized_uparm(parm, expected):
     with pytest.raises(UnrecognizedParameterException) as upe:
         GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=parm, upload=None, config_file=None)
     assert expected in str(upe.value)
+
+
+def test_parm_recheck_bad_values_every_time():
+    """ Test handling of unrecognized user parameters. """
+    # quick argparse to mimic a call from reduce.py
+    testfile = download_from_archive("N20160524S0119.fits")
+
+    with pytest.raises(UnrecognizedParameterException) as upe:
+        GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('nteractive', True)], upload=None,
+                     config_file=None)
+    with pytest.raises(UnrecognizedParameterException) as upe2:
+        GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('nteractive', True)], upload=None,
+                     config_file=None)
+    assert(upe2 is not None)  # subsequent runs with bad parameters should still abort
+
+
+def test_parm_dont_recheck_same_passing_parms(monkeypatch):
+    """ Test handling of unrecognized user parameters. """
+    # quick argparse to mimic a call from reduce.py
+    testfile = download_from_archive("N20160524S0119.fits")
+
+    GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('interactive', True)], upload=None,
+                 config_file=None)
+
+    def mock_find_similar_names(name, valid_names):
+        # Even though we monkeypatch this in, this function will not be called.
+        # The PrimitivesBase will see that we are passing the same uparms and will
+        # skip the parameter validation step, where this would normally be called
+        return ["this_causes_check_to_throw_exception",]
+    monkeypatch.setattr(geminidr, "_find_similar_names", mock_find_similar_names)
+    GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('interactive', True)], upload=None,
+                 config_file=None)

--- a/geminidr/tests/test_geminidr.py
+++ b/geminidr/tests/test_geminidr.py
@@ -1,0 +1,29 @@
+import pytest
+from astrodata.testing import download_from_archive
+from geminidr.gmos.primitives_gmos_longslit import GMOSLongslit
+from recipe_system.reduction.coreReduce import UnrecognizedParameterException
+
+import astrodata
+import gemini_instruments  # needed to initialize instrument support
+
+
+@pytest.mark.parametrize('parm, expected',
+                         [
+                             ([('nteractive', True)], 'Parameter nteractive not recognized'),
+                             ([('calculateSensitivity:nteractive', True)], 'Parameter nteractive not recognized'),
+                             ([('alculateSensitivity:interactive', True)], 'Primitive alculateSensitivity not found'),
+                             ([('calculateSensitivity:Interactive', True)],
+                              'Parameter Interactive not found, did you mean interactive?'),
+                             ([('CalculateSensitivity:interactive', True)],
+                              'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
+                             ([('calculateSensitivity:interactive:pickles', True)],
+                              'Expecting parameter or primitive:parameter in -p user parameters')
+                         ])
+def test_unrecognized_uparm(parm, expected):
+    """ Test handling of unrecognized user parameters. """
+    # quick argparse to mimic a call from reduce.py
+    testfile = download_from_archive("N20160524S0119.fits")
+
+    with pytest.raises(UnrecognizedParameterException) as upe:
+        GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=parm, upload=None, config_file=None)
+    assert expected in str(upe.value)

--- a/geminidr/tests/test_geminidr.py
+++ b/geminidr/tests/test_geminidr.py
@@ -19,7 +19,9 @@ import gemini_instruments  # needed to initialize instrument support
                              ([('CalculateSensitivity:interactive', True)],
                               'Primitive CalculateSensitivity not recognized, did you mean calculateSensitivity?'),
                              ([('calculateSensitivity:interactive:pickles', True)],
-                              'Expecting parameter or primitive:parameter in -p user parameters')
+                              'Expecting parameter or primitive:parameter in -p user parameters'),
+                             ([('calculateSensitivity:intiractive', True)],
+                              'Parameter intiractive not recognized, did you mean interactive?')
                          ])
 def test_unrecognized_uparm(parm, expected):
     """ Test handling of unrecognized user parameters. """

--- a/geminidr/tests/test_geminidr.py
+++ b/geminidr/tests/test_geminidr.py
@@ -31,33 +31,5 @@ def test_unrecognized_uparm(parm, expected):
     assert expected in str(upe.value)
 
 
-def test_parm_recheck_bad_values_every_time():
-    """ Test handling of unrecognized user parameters. """
-    # quick argparse to mimic a call from reduce.py
-    testfile = download_from_archive("N20160524S0119.fits")
-
-    with pytest.raises(UnrecognizedParameterException) as upe:
-        GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('nteractive', True)], upload=None,
-                     config_file=None)
-    with pytest.raises(UnrecognizedParameterException) as upe2:
-        GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('nteractive', True)], upload=None,
-                     config_file=None)
-    assert(upe2 is not None)  # subsequent runs with bad parameters should still abort
-
-
-def test_parm_dont_recheck_same_passing_parms(monkeypatch):
-    """ Test handling of unrecognized user parameters. """
-    # quick argparse to mimic a call from reduce.py
-    testfile = download_from_archive("N20160524S0119.fits")
-
-    GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('interactive', True)], upload=None,
-                 config_file=None)
-
-    def mock_find_similar_names(name, valid_names):
-        # Even though we monkeypatch this in, this function will not be called.
-        # The PrimitivesBase will see that we are passing the same uparms and will
-        # skip the parameter validation step, where this would normally be called
-        return ["this_causes_check_to_throw_exception",]
-    monkeypatch.setattr(geminidr, "_find_similar_names", mock_find_similar_names)
-    GMOSLongslit(astrodata.open(testfile), mode='sq', ucals={}, uparms=[('interactive', True)], upload=None,
-                 config_file=None)
+if __name__ == "__main__":
+    pytest.main()

--- a/gempy/utils/soundex.py
+++ b/gempy/utils/soundex.py
@@ -1,0 +1,54 @@
+""" Taken from Jellyfish
+
+Just extracting this from jellyfish so we don't need to pull
+in the entire library.  This is only used for finding alternatives
+when the user supplies a parameter that isn't recognized.
+
+See: https://github.com/jamesturk/jellyfish
+"""
+import unicodedata
+
+
+def soundex(s):
+    if not s:
+        return ""
+
+    s = unicodedata.normalize("NFKD", s)
+    s = s.upper()
+
+    replacements = (
+        ("BFPV", "1"),
+        ("CGJKQSXZ", "2"),
+        ("DT", "3"),
+        ("L", "4"),
+        ("MN", "5"),
+        ("R", "6"),
+    )
+    result = [s[0]]
+    count = 1
+
+    # find would-be replacment for first character
+    for lset, sub in replacements:
+        if s[0] in lset:
+            last = sub
+            break
+    else:
+        last = None
+
+    for letter in s[1:]:
+        for lset, sub in replacements:
+            if letter in lset:
+                if sub != last:
+                    result.append(sub)
+                    count += 1
+                last = sub
+                break
+        else:
+            if letter != "H" and letter != "W":
+                # leave last alone if middle letter is H or W
+                last = None
+        if count == 4:
+            break
+
+    result += "0" * (4 - count)
+    return "".join(result)

--- a/gempy/utils/soundex.py
+++ b/gempy/utils/soundex.py
@@ -5,6 +5,34 @@ in the entire library.  This is only used for finding alternatives
 when the user supplies a parameter that isn't recognized.
 
 See: https://github.com/jamesturk/jellyfish
+
+LICENSE:
+
+Copyright (c) 2015, James Turk
+Copyright (c) 2015, Sunlight Foundation
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 import unicodedata
 

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -151,8 +151,8 @@ class Reduce:
             if ':' in key:
                 split_key = key.split(':')
                 if len(split_key) != 2:
-                    raise UnrecognizedParameterException("Expecting parameter or primitive:parameter in \
-                        -p user parameters")
+                    raise UnrecognizedParameterException("Expecting parameter or primitive:parameter in "
+                                                         "-p user parameters")
                 primitive = split_key[0]
                 key = split_key[1]
             found_primitive = False

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -134,71 +134,6 @@ class Reduce:
         self._output_filenames = None
         self.recipename = args.recipename if args.recipename else '_default'
 
-    def _validate_uparms(self):
-        """
-        Validate the user parameters.
-
-        This is an internal method that checks the user parameters for
-        any obvious issues.  This lets us fail fast in case the user
-        made an error.
-
-        :raises: :class:~recipe_system.reduction.coreReduce.UnrecognizedParameterException: \
-            when a user parameter uses an unrecognized primitive or parameter name
-        """
-        if self.uparms:
-            for uparm in self.uparms:
-                key = uparm[0]
-                primitive = None
-                if ':' in key:
-                    split_key = key.split(':')
-                    if len(split_key) != 2:
-                        raise UnrecognizedParameterException("Expecting parameter or primitive:parameter in "
-                                                             "-p user parameters")
-                    primitive = split_key[0]
-                    key = split_key[1]
-                found_primitive = False
-                found_key = False
-                alternative_keys = list()
-                alternative_primitives = list()
-
-                def big_generator(base_class=config.Config):
-                    for cfg_class in base_class.__subclasses__():
-                        yield cfg_class
-                        for cfg_subclass in big_generator(cfg_class):
-                            yield cfg_subclass
-
-                for cfg_class in big_generator():
-                    if (primitive is None or f"{primitive}Config" == cfg_class.__name__) and \
-                            not cfg_class.__name__.startswith('core_'):
-                        found_primitive = True
-                        if primitive is None or f"{primitive}Config" == cfg_class.__name__:
-                            # We have to use _fields to avoid having to instantiate the config here
-                            for field_name, field_typ in cfg_class._fields.items():  # pylint: disable=protected-access
-                                if key == field_name:
-                                    found_key = True
-                                elif key.upper() == field_name.upper() and field_name not in alternative_keys:
-                                    alternative_keys.append(field_name)
-                    if primitive is not None:
-                        if f"{primitive.upper()}CONFIG" == cfg_class.__name__.upper() \
-                                and cfg_class.__name__[0:-6] not in alternative_primitives:
-                            alternative_primitives.append(cfg_class.__name__[0:-6])
-                if primitive and not found_primitive:
-                    if alternative_primitives:
-                        if len(alternative_primitives) == 1:
-                            raise UnrecognizedParameterException(f"Primitive {primitive} not found, did you mean {alternative_primitives[0]}?")
-                        else:
-                            raise UnrecognizedParameterException(f"Primitive {primitive} not found, did you mean one of {alternative_primitives}?")
-                    else:
-                        raise UnrecognizedParameterException(f"Primitive {primitive} not found")
-                if not found_key:
-                    if alternative_keys:
-                        if len(alternative_keys) == 1:
-                            raise UnrecognizedParameterException(f"Parameter {key} not found, did you mean {alternative_keys[0]}?")
-                        else:
-                            raise UnrecognizedParameterException(f"Parameter {key} not found, did you mean one of these? {alternative_keys}?")
-                    else:
-                        raise UnrecognizedParameterException(f"Parameter {key} not recognized")
-
     @property
     def upload(self):
         return self._upload
@@ -300,7 +235,6 @@ class Reduce:
             log.stdinfo("Found '{}' as a primitive.".format(pname))
             self._logheader(pname)
             try:
-                self._validate_uparms()
                 primitive_as_recipe()
             except Exception as err:
                 log_traceback(log)
@@ -309,7 +243,6 @@ class Reduce:
         else:
             self._logheader(recipe)
             try:
-                self._validate_uparms()
                 recipe(p)
             except Exception:
                 log.error("Reduce received an unhandled exception. Aborting ...")

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -198,8 +198,6 @@ class Reduce:
                 else:
                     raise UnrecognizedParameterException(f"Parameter {key} not recognized")
 
-        exit(0)
-
     @property
     def upload(self):
         return self._upload

--- a/recipe_system/reduction/tests/test_coreReduce.py
+++ b/recipe_system/reduction/tests/test_coreReduce.py
@@ -1,7 +1,8 @@
 import pytest
 from astrodata.testing import download_from_archive
-from recipe_system.reduction.coreReduce import Reduce
+from recipe_system.reduction.coreReduce import Reduce, UnrecognizedParameterException
 from recipe_system.utils.errors import RecipeNotFound
+from recipe_system.utils.reduce_utils import buildParser, normalize_args, normalize_upload
 
 
 @pytest.mark.dragons_remote_data
@@ -25,3 +26,29 @@ def test_mode_not_found():
     with pytest.raises(RecipeNotFound,
                        match="GMOS recipes do not define a 'aa' recipe"):
         red.runr()
+
+
+@pytest.mark.parameterize('parm, expected',
+                          [
+                              ('calculateSensitivity:nteractive=True', 'Parameter nteractive not found'),
+                              ('alculateSensitivity:interactive=True', 'Primitive alculateSensitivity not found'),
+                              ('calculateSensitivity:Interactive=True',
+                               'Parameter Interactive not found, did you mean interactive?'),
+                              ('CalculateSensitivity:interactive=True',
+                               'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
+                              ('calculateSensitivity:interactive:pickles=True',
+                               'Expecting parameter or primitive:parameter in -p user parameters')
+                          ])
+def test_unrecognized_uparm(parm, expected):
+    """ Test handling of unrecognized user parameters. """
+    # quick argparse to mimic a call from reduce.py
+    parser = buildParser()
+    args = parser.parse_args(['-p', parm, '-r', 'calculateSensitivity', 'calculatesensitivity_example.fits'])
+    args = normalize_args(args)
+    args.upload = normalize_upload(args.upload)
+
+    red = Reduce(sys_args=args)
+
+    with pytest.raises(UnrecognizedParameterException) as upe:
+        red.runr()
+    assert expected in str(upe.value)

--- a/recipe_system/reduction/tests/test_coreReduce.py
+++ b/recipe_system/reduction/tests/test_coreReduce.py
@@ -1,9 +1,7 @@
 import pytest
 from astrodata.testing import download_from_archive
-from recipe_system.reduction.coreReduce import Reduce, UnrecognizedParameterException
+from recipe_system.reduction.coreReduce import Reduce
 from recipe_system.utils.errors import RecipeNotFound
-from recipe_system.utils.reduce_utils import buildParser, normalize_args, normalize_upload
-from recipe_system import __version__ as rs_version
 
 
 @pytest.mark.dragons_remote_data
@@ -27,32 +25,3 @@ def test_mode_not_found():
     with pytest.raises(RecipeNotFound,
                        match="GMOS recipes do not define a 'aa' recipe"):
         red.runr()
-
-
-@pytest.mark.parametrize('parm, expected',
-                         [
-                             ('nteractive=True', 'Parameter nteractive not recognized'),
-                             ('calculateSensitivity:nteractive=True', 'Parameter nteractive not recognized'),
-                             ('alculateSensitivity:interactive=True', 'Primitive alculateSensitivity not found'),
-                             ('calculateSensitivity:Interactive=True',
-                              'Parameter Interactive not found, did you mean interactive?'),
-                             ('CalculateSensitivity:interactive=True',
-                              'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
-                             ('calculateSensitivity:interactive:pickles=True',
-                              'Expecting parameter or primitive:parameter in -p user parameters')
-                         ])
-def test_unrecognized_uparm(parm, expected, monkeypatch):
-    """ Test handling of unrecognized user parameters. """
-    # quick argparse to mimic a call from reduce.py
-    testfile = download_from_archive("N20160524S0119.fits")
-
-    parser = buildParser(rs_version)
-    args = parser.parse_args(['-p', parm, '-r', 'calculateSensitivity', "N20160524S0119.fits"])
-    args = normalize_args(args)
-    args.upload = normalize_upload(args.upload)
-
-    red = Reduce(sys_args=args)
-    red.files = [testfile]
-    with pytest.raises(UnrecognizedParameterException) as upe:
-        red.runr()
-    assert expected in str(upe.value)

--- a/recipe_system/reduction/tests/test_coreReduce.py
+++ b/recipe_system/reduction/tests/test_coreReduce.py
@@ -28,17 +28,17 @@ def test_mode_not_found():
         red.runr()
 
 
-@pytest.mark.parameterize('parm, expected',
-                          [
-                              ('calculateSensitivity:nteractive=True', 'Parameter nteractive not found'),
-                              ('alculateSensitivity:interactive=True', 'Primitive alculateSensitivity not found'),
-                              ('calculateSensitivity:Interactive=True',
-                               'Parameter Interactive not found, did you mean interactive?'),
-                              ('CalculateSensitivity:interactive=True',
-                               'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
-                              ('calculateSensitivity:interactive:pickles=True',
-                               'Expecting parameter or primitive:parameter in -p user parameters')
-                          ])
+@pytest.mark.parametrize('parm, expected',
+                         [
+                             ('calculateSensitivity:nteractive=True', 'Parameter nteractive not found'),
+                             ('alculateSensitivity:interactive=True', 'Primitive alculateSensitivity not found'),
+                             ('calculateSensitivity:Interactive=True',
+                              'Parameter Interactive not found, did you mean interactive?'),
+                             ('CalculateSensitivity:interactive=True',
+                              'Primitive CalculateSensitivity not found, did you mean calculateSensitivity?'),
+                             ('calculateSensitivity:interactive:pickles=True',
+                              'Expecting parameter or primitive:parameter in -p user parameters')
+                         ])
 def test_unrecognized_uparm(parm, expected):
     """ Test handling of unrecognized user parameters. """
     # quick argparse to mimic a call from reduce.py

--- a/recipe_system/reduction/tests/test_coreReduce.py
+++ b/recipe_system/reduction/tests/test_coreReduce.py
@@ -3,6 +3,7 @@ from astrodata.testing import download_from_archive
 from recipe_system.reduction.coreReduce import Reduce, UnrecognizedParameterException
 from recipe_system.utils.errors import RecipeNotFound
 from recipe_system.utils.reduce_utils import buildParser, normalize_args, normalize_upload
+from recipe_system import __version__ as rs_version
 
 
 @pytest.mark.dragons_remote_data
@@ -30,7 +31,8 @@ def test_mode_not_found():
 
 @pytest.mark.parametrize('parm, expected',
                          [
-                             ('calculateSensitivity:nteractive=True', 'Parameter nteractive not found'),
+                             ('nteractive=True', 'Parameter nteractive not recognized'),
+                             ('calculateSensitivity:nteractive=True', 'Parameter nteractive not recognized'),
                              ('alculateSensitivity:interactive=True', 'Primitive alculateSensitivity not found'),
                              ('calculateSensitivity:Interactive=True',
                               'Parameter Interactive not found, did you mean interactive?'),
@@ -39,16 +41,18 @@ def test_mode_not_found():
                              ('calculateSensitivity:interactive:pickles=True',
                               'Expecting parameter or primitive:parameter in -p user parameters')
                          ])
-def test_unrecognized_uparm(parm, expected):
+def test_unrecognized_uparm(parm, expected, monkeypatch):
     """ Test handling of unrecognized user parameters. """
     # quick argparse to mimic a call from reduce.py
-    parser = buildParser()
-    args = parser.parse_args(['-p', parm, '-r', 'calculateSensitivity', 'calculatesensitivity_example.fits'])
+    testfile = download_from_archive("N20160524S0119.fits")
+
+    parser = buildParser(rs_version)
+    args = parser.parse_args(['-p', parm, '-r', 'calculateSensitivity', "N20160524S0119.fits"])
     args = normalize_args(args)
     args.upload = normalize_upload(args.upload)
 
     red = Reduce(sys_args=args)
-
+    red.files = [testfile]
     with pytest.raises(UnrecognizedParameterException) as upe:
         red.runr()
     assert expected in str(upe.value)


### PR DESCRIPTION
check for unrecognized parameters (or primitive:parameters)

This will fail-fast in Reduce() with a more readable error if the user:
* Passes a parameter name that is not present in any loaded Config definitions
* Passes a primitive:parameter where that parameter is not present in that primitive Config definition
* Passes a primitive:parameter where the primitive is not recognized (i.e. has no Config definition)
* Passes a thing with two or more colons that we can't interpret
