### PR TITLE
Adding stackBiases primitive

### DIFF
--- a/geminidr/core/parameters_ccd.py
+++ b/geminidr/core/parameters_ccd.py
@@ -2,12 +2,20 @@
 # in the primitives_ccd.py file, in alphabetical order.
 from gempy.library import config
 from astrodata import AstroData
-from . import parameters_generic
+from . import parameters_generic, parameters_stack
 
 class biasCorrectConfig(parameters_generic.calRequirementConfig):
     suffix = config.Field("Filename suffix", str, "_biasCorrected", optional=True)
     bias = config.ListField("Bias(es) to subtract", (AstroData, str), None,
                             optional=True, single=True)
+
+
+class stackBiasesConfig(parameters_stack.stackFramesConfig):
+
+    def setDefaults(self):
+        self.reject_method = 'varclip'
+        del self.zero
+        del self.scale
 
 
 class subtractOverscanConfig(config.core_1Dfitting_config):

--- a/geminidr/core/parameters_nearIR.py
+++ b/geminidr/core/parameters_nearIR.py
@@ -35,4 +35,7 @@ class separateFlatsDarksConfig(config.Config):
     pass
 
 class stackDarksConfig(parameters_stack.core_stacking_config):
-    pass
+
+    def setDefaults(self):
+        del self.zero
+        del self.scale

--- a/geminidr/core/primitives_ccd.py
+++ b/geminidr/core/primitives_ccd.py
@@ -104,6 +104,21 @@ class CCD(PrimitivesBASE):
             timestamp = datetime.now()
         return adinputs
 
+    def stackBiases(self, adinputs=None, **params):
+        """
+        This primitive checks the inputs have the same exposure time and stacks
+        them without any scaling offsetting, suitable for biases.
+        """
+        log = self.log
+        log.debug(gt.log_message("primitve", self.myself(), "starting"))
+
+        if not all('BIAS' in bias.tags for bias in adinputs):
+            raise OSError("Not all inputs have BIAS tag")
+
+        stack_params = self._inherit_params(params, "stackFrames")
+        adinputs = self.stackFrames(adinputs, **stack_params)
+        return adinputs
+
     def overscanCorrect(self, adinputs=None, **params):
         adinputs = self.subtractOverscan(adinputs,
                     **self._inherit_params(params, "subtractOverscan"))

--- a/geminidr/core/primitives_ccd.py
+++ b/geminidr/core/primitives_ccd.py
@@ -116,6 +116,7 @@ class CCD(PrimitivesBASE):
             raise OSError("Not all inputs have BIAS tag")
 
         stack_params = self._inherit_params(params, "stackFrames")
+        stack_params.update({'zero': False, 'scale': False})
         adinputs = self.stackFrames(adinputs, **stack_params)
         return adinputs
 

--- a/geminidr/core/tests/test_ccd.py
+++ b/geminidr/core/tests/test_ccd.py
@@ -1,0 +1,54 @@
+"""
+Tests applied to primitives_ccd.py
+"""
+
+from astropy.io import fits
+import numpy as np
+import pytest
+
+from geminidr.gmos.primitives_gmos import GMOS
+
+# -- Tests --------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_biases():
+    return [create_bias(100, 100) for i in range(5)]
+
+@pytest.mark.parametrize("rejection_method", ('varclip', 'sigclip', 'minmax'))
+def test_stack_biases(rejection_method, fake_biases):
+
+    p = GMOS(fake_biases)
+    p.addVAR()
+    ad_out = p.stackBiases(reject_method=rejection_method)
+    assert(len(ad_out)) == 1
+    assert ad_out[0].data[0][0, 0] == 1.
+
+
+def test_non_bias_mixed_in(fake_biases):
+
+    # Remove BIAS tag from one fake input astrodata object
+    fake_biases[0].tags = fake_biases[0].tags.difference({'BIAS'})
+    p = GMOS(fake_biases)
+
+    with pytest.raises(OSError, match='Not all inputs have BIAS tag'):
+        p.stackBiases()
+
+
+def create_bias(height, width):
+
+    astrofaker = pytest.importorskip("astrofaker")
+
+    data = np.ones((height, width))
+    hdu = fits.ImageHDU()
+    hdu.data = data
+
+    ad = astrofaker.create('GMOS-N')
+    ad.add_extension(hdu, pixel_scale=1)
+    ad.tags = ad.tags.union({'BIAS'})
+
+    return ad
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/geminidr/core/tests/test_ccd.py
+++ b/geminidr/core/tests/test_ccd.py
@@ -10,18 +10,23 @@ from geminidr.gmos.primitives_gmos import GMOS
 
 # -- Tests --------------------------------------------------------------------
 
-
+# Create a set of fake biases
 @pytest.fixture(scope='module')
 def fake_biases():
     return [create_bias(100, 100, i) for i in (0, 1, 2, 2, 3)]
 
 @pytest.mark.parametrize("rejection_method, expected",
-                         [('varclip', 1.6), ('sigclip', 1.6), ('minmax', 1.6)])
+                         [('varclip', 2.),
+                          ('sigclip', 1.6),
+                          ('minmax', 1.666666)])
 def test_stack_biases(rejection_method, expected, fake_biases):
 
     p = GMOS(fake_biases)
     p.addVAR()
-    ad_out = p.stackBiases(reject_method=rejection_method)
+    if rejection_method == 'minmax':
+        ad_out = p.stackBiases(reject_method=rejection_method, nlow=1, nhigh=1)
+    else:
+        ad_out = p.stackBiases(reject_method=rejection_method)
     assert(len(ad_out)) == 1
     assert pytest.approx(ad_out[0].data[0]) == expected
 
@@ -47,6 +52,9 @@ def create_bias(height, width, value):
     ad = astrofaker.create('GMOS-N')
     ad.add_extension(hdu, pixel_scale=1)
     ad.tags = ad.tags.union({'BIAS'})
+    for ext in ad:
+        ext.variance = np.where(ext.data > 0,
+                                ext.data, 0).astype(np.float32)
 
     return ad
 

--- a/geminidr/gmos/recipes/qa/recipes_BIAS.py
+++ b/geminidr/gmos/recipes/qa/recipes_BIAS.py
@@ -23,7 +23,7 @@ def makeProcessedBias(p):
     p.overscanCorrect()
     p.addToList(purpose="forStack")
     p.getList(purpose="forStack")
-    p.stackFrames()
+    p.stackBiases()
     p.storeProcessedBias()
     return
 

--- a/geminidr/gmos/recipes/sq/recipes_BIAS.py
+++ b/geminidr/gmos/recipes/sq/recipes_BIAS.py
@@ -23,7 +23,7 @@ def makeProcessedBias(p):
     p.addDQ(static_bpm=None)
     p.addVAR(read_noise=True)
     p.overscanCorrect()
-    p.stackFrames(zero=False)
+    p.stackBiases()
     p.makeIRAFCompatible()
     p.storeProcessedBias()
     return


### PR DESCRIPTION
This PR adds a new stackBiases primitive and two tests for it, and replaces stackFrames with stackBiases in gmos/recipes. The default rejection method is 'varclip', and the `zero` and `scale` option are not exposed to users.

It also tweaks stackDarks to remove `zero` and `scale` as user-facing options.