### PR TITLE
removing formating for text box number entry

### DIFF
--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -818,8 +818,6 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
         if val is None and allow_none:
             return True
         try:
-            if isinstance(val, str) and ',' in val:
-                val.replace(',', '')
             if is_float:
                 float(val)
             else:

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -779,7 +779,6 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
     # below to enforce the range limits, if any.
     if not hide_textbox:
         text_input = NumericInput(width=64, value=value,
-                                  format=fmt,
                                   mode='float' if is_float else 'int')
 
         # Custom range enforcement with alert messages
@@ -819,6 +818,8 @@ def build_text_slider(title, value, step, min_value, max_value, obj=None,
         if val is None and allow_none:
             return True
         try:
+            if isinstance(val, str) and ',' in val:
+                val.replace(',', '')
             if is_float:
                 float(val)
             else:


### PR DESCRIPTION
The formatting in the numeric text box in bokeh has trouble when deleting digits off the end.  Bokeh just highlights text but doesn't adjust the value displayed unti the , is reached.  Fixed by removing the formatting.
