### PR TITLE
locking down relevant reduce parameters to be single-value

### DIFF
--- a/recipe_system/utils/reduce_utils.py
+++ b/recipe_system/utils/reduce_utils.py
@@ -82,24 +82,24 @@ def buildParser(version):
                         help="fitsfile [fitsfile ...] ")
 
     parser.add_argument("--adpkg", dest='adpkg', default=None,
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Specify an external astrodata definitions package. "
                         "This is only passed for non-Gemini instruments."
                         "The package must be importable. E.g., "
                         "--adpkg soar_instruments ")
 
     parser.add_argument("--drpkg", dest='drpkg', default='geminidr',
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Specify another data reduction (dr) package. "
                         "The package must be importable. Recipe system default is "
                         "'geminidr'. E.g., --drpkg ghostdr ")
 
     parser.add_argument("--logfile", dest="logfile", default="reduce.log",
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="name of log (default is 'reduce.log')")
 
     parser.add_argument("--logmode", dest="logmode", default="standard",
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Set log mode: 'standard', 'quiet', 'debug'. "
                         "Default is 'standard'. 'quiet' writes only to log file.")
 
@@ -122,7 +122,7 @@ def buildParser(version):
                         "Default is to use 'sq' recipes.")
 
     parser.add_argument("-r", "--recipe", dest="recipename", default=None,
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Specify a recipe by name. Users can request "
                         "non-default system recipe functions by their simple "
                         "names, e.g., -r qaStack, OR may specify their own "
@@ -142,7 +142,7 @@ def buildParser(version):
                         "is a python module named,  'recipefile.py' ")
 
     parser.add_argument("--suffix", dest='suffix', default=None,
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Add 'suffix' to filenames at end of reduction; "
                         "strip all other suffixes marked by '_'; ")
 
@@ -159,7 +159,7 @@ def buildParser(version):
                         "Eg., --user_cal processed_arc:gsTest_arc.fits")
 
     parser.add_argument("-c", "--config", dest='config', default=None,
-                        nargs="*", action=UnitaryArgumentAction,
+                        nargs=1, action=UnitaryArgumentAction,
                         help="Load a specific config file, overriding the "
                              "~/.geminidr/rsys.cfg file and the $DRAGONSRC "
                              "environment variable.")


### PR DESCRIPTION
locking down relevant reduce parameters to be single-value, producing appropriate error messages for extra unrecognized parameters rather than tacking them onto one of these options and then ignoring it