### PR TITLE
GMOS scaleByIntensity - Use the masks for the stats

### DIFF
--- a/geminidr/gmos/primitives_gmos_image.py
+++ b/geminidr/gmos/primitives_gmos_image.py
@@ -358,7 +358,34 @@ class GMOSImage(GMOS, Image, Photometry):
         log.debug(gt.log_message("primitive", self.myself(), "starting"))
         timestamp_key = self.timestamp_keys[self.myself()]
 
-        ref_mean = None
+        # Check that the all the files have the same structure
+        structure_okay = True
+        ref_nbext = None
+        ref_shape = None
+        ref_filename = None
+        for ad in adinputs:
+            nbext = len(ad)
+            shape = ad[0].data.shape  # should we check all extensions?
+            if ref_nbext is None:
+                ref_nbext = nbext
+                ref_shape = shape
+                ref_filename = ad.filename
+            else:
+                if nbext != ref_nbext:
+                    structure_okay = False
+                    log.warning("{} - Different number of extensions compared "
+                                "reference frame ({}).".
+                                format(ad.filename, ref_filename))
+                if shape != ref_shape:
+                    structure_okay = False
+                    log.warning("{} - Different shape compared to reference "
+                                " frame ({}).").\
+                                format(ad.filename, ref_filename)
+        if not structure_okay:
+            raise ValueError('The input data have different file structure.')
+
+        ref_stat_region = None
+        ref_mask = None
         for ad in adinputs:
             # If this input hasn't been tiled at all, tile it
             ad_for_stats = self.tileArrays([deepcopy(ad)], tile_all=False)[0] \
@@ -367,8 +394,10 @@ class GMOSImage(GMOS, Image, Photometry):
             # Use CCD2, or the entire mosaic if we can't find a second extn
             try:
                 data = ad_for_stats[1].data
+                mask = ad_for_stats[1].mask
             except IndexError:
                 data = ad_for_stats[0].data
+                mask = ad_for_stats[0].mask
 
             # Take off 5% of the width as a border
             xborder = max(int(0.05 * data.shape[1]), 20)
@@ -378,11 +407,27 @@ class GMOSImage(GMOS, Image, Photometry):
                                              yborder, data.shape[0] - yborder))
 
             stat_region = data[yborder:-yborder, xborder:-xborder]
-            mean = np.mean(stat_region)
+            if ref_stat_region is None:
+                ref_stat_region = data[yborder:-yborder, xborder:-xborder]
+                ref_mask = mask
+
+            combined_mask = None
+            if mask is not None and ref_mask is not None:
+                combined_mask = ref_mask | mask
+            elif mask is not None:
+                combined_mask = mask
+            elif ref_mask is not None:
+                combined_mask = ref_mask
+
+            if combined_mask is not None:
+                mask_region = combined_mask[yborder:-yborder, xborder:-xborder]
+                mean = np.mean(stat_region[mask_region == 0])
+                ref_mean = np.mean(ref_stat_region[mask_region == 0])
+            else:
+                mean = np.mean(stat_region)
+                ref_mean = np.mean(ref_stat_region)
 
             # Set reference level to the first image's mean
-            if ref_mean is None:
-                ref_mean = mean
             scale = ref_mean / mean
 
             # Log and save the scale factor, and multiply by it

--- a/geminidr/gmos/recipes/qa/tests/test_flat_image.py
+++ b/geminidr/gmos/recipes/qa/tests/test_flat_image.py
@@ -63,7 +63,7 @@ def test_make_processed_flat(
         data = np.ma.masked_array(ext.data, mask=ext.mask)
 
         if not data.mask.all():
-            np.testing.assert_allclose(np.ma.median(data.ravel()), 1, atol=0.071)
+            np.testing.assert_allclose(np.ma.median(data.ravel()), 1, atol=0.072)
             np.testing.assert_allclose(data[~data.mask], 1, atol=0.45)
 
     # plot(ad)


### PR DESCRIPTION
The GMOS version of scaleByIntensity was not using the mask to calculate the stats.  That really caused trouble with the GMOS-S amp 5 issues.  

Added use of mask, combining the reference frame mask and current frame mask to ensure that the pixels uses are all good.  Added checks on number of extensions and frame sizes.  