### PR TITLE
Use UTC timezone for header timestamps

### DIFF
--- a/gempy/gemini/gemini_tools.py
+++ b/gempy/gemini/gemini_tools.py
@@ -1299,7 +1299,7 @@ def mark_history(adinput=None, keyword=None, primname=None, comment=None):
         raise TypeError("argument 'keyword' required")
 
     # Get the current time to use for the time of last modification
-    tlm = datetime.now().isoformat()[0:-7]
+    tlm = datetime.utcnow().isoformat()
 
     # Construct the default comment
     if comment is None:


### PR DESCRIPTION
The history timestamps in the header refer to UTC in their comment but are pulling localtime.  Changed the utility method to use UTC time and increased precision