### PR TITLE
fixes to pytest approx for pytest 7.0.x

### DIFF
--- a/gemini_instruments/cirpass/tests/test_cirpass.py
+++ b/gemini_instruments/cirpass/tests/test_cirpass.py
@@ -9,8 +9,8 @@ def test_ra_dec_from_text():
     ad = AstroDataCirpass()
     ad.phu['TEL_RA'] = '03:48:30.113'
     ad.phu['TEL_DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.ra(), 57.12547083333333)
-    assert pytest.approx(ad.dec(), 24.345277777777778)
+    assert ad.ra() == pytest.approx(57.12547083333333)
+    assert ad.dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/f2/tests/test_f2.py
+++ b/gemini_instruments/f2/tests/test_f2.py
@@ -101,8 +101,8 @@ def test_ra_dec_from_text(astrofaker):
     ad = AstroDataF2()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/gmos/tests/test_gmos.py
+++ b/gemini_instruments/gmos/tests/test_gmos.py
@@ -76,8 +76,8 @@ def test_ra_dec_from_text(astrofaker):
                                            'DEC': '+24:20:43.00',
                                            'DATE-OBS': '2021-01-01T12:00:00.000'}
                            )
-    assert pytest.approx(ad.ra(), 57.12547083333333)
-    assert pytest.approx(ad.dec(), 24.345277777777778)
+    assert ad.ra() == pytest.approx(57.12547083333333)
+    assert ad.dec() == pytest.approx(24.345277777777778)
 
     # test bad RA/DEC values, just doing this for GMOS but it's testing the base
     ad = astrofaker.create('GMOS-S', ['SPECT'],

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -162,8 +162,8 @@ def test_ra_dec_from_text():
     ad = AstroDataGnirs()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/gsaoi/tests/test_gsaoi.py
+++ b/gemini_instruments/gsaoi/tests/test_gsaoi.py
@@ -7,8 +7,8 @@ def test_ra_dec_from_text():
     ad = AstroDataGsaoi()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/hokupaa_quirc/tests/test_hokupaa_quirc.py
+++ b/gemini_instruments/hokupaa_quirc/tests/test_hokupaa_quirc.py
@@ -9,8 +9,8 @@ def test_ra_dec_from_text():
     ad = AstroDataHokupaaQUIRC()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.ra(), 57.12547083333333)
-    assert pytest.approx(ad.dec(), 24.345277777777778)
+    assert ad.ra() == pytest.approx(57.12547083333333)
+    assert ad.dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/niri/tests/test_niri.py
+++ b/gemini_instruments/niri/tests/test_niri.py
@@ -74,8 +74,8 @@ def test_ra_dec_from_text(astrofaker):
                                            'DEC': '+24:20:43.00',
                                            'DATE-OBS': '2021-01-01T12:00:00.000'}
                            )
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
     from astropy import units as u
 

--- a/gemini_instruments/oscir/tests/test_oscir.py
+++ b/gemini_instruments/oscir/tests/test_oscir.py
@@ -7,10 +7,10 @@ def test_ra_dec_from_text():
     ad = AstroDataOscir()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.ra(), 57.12547083333333)
-    assert pytest.approx(ad.dec(), 24.345277777777778)
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.ra() == pytest.approx(57.12547083333333)
+    assert ad.dec() == pytest.approx(24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/texes/tests/test_texes.py
+++ b/gemini_instruments/texes/tests/test_texes.py
@@ -8,10 +8,10 @@ def test_ra_dec_from_text():
     ad = AstroDataTexes()
     ad.phu['RA'] = '03:48:30.113'
     ad.phu['DEC'] = '+24:20:43.00'
-    assert pytest.approx(ad.ra(), 57.12547083333333)
-    assert pytest.approx(ad.dec(), 24.345277777777778)
-    assert pytest.approx(ad.target_ra(), 57.12547083333333)
-    assert pytest.approx(ad.target_dec(), 24.345277777777778)
+    assert ad.ra() == pytest.approx(57.12547083333333)
+    assert ad.dec() == pytest.approx(24.345277777777778)
+    assert ad.target_ra() == pytest.approx(57.12547083333333)
+    assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I was misusing approx in ra/dec testing and pytest 7.0.0 enforces a == approx(b)