### PR TITLE
F2 LYOT handling fixes

### DIFF
--- a/gemini_instruments/f2/adclass.py
+++ b/gemini_instruments/f2/adclass.py
@@ -504,6 +504,23 @@ class AstroDataF2(AstroDataGemini):
     #     """
     #     return 'F2'
 
+    @astro_data_descriptor
+    def lyot_stop(self):
+        """
+        Returns the LYOT filter used for the observation.  This works around
+        inconsistencies in the header keywords.
+
+        Returns
+        -------
+        str
+            LYOT filter name, or None
+
+        """
+        lyot = self.phu.get('LYOT', None)
+        if lyot:
+            return lyot
+        return self.phu.get('LYOTPOS', None)
+
     @returns_list
     @astro_data_descriptor
     def nominal_photometric_zeropoint(self):

--- a/gemini_instruments/f2/adclass.py
+++ b/gemini_instruments/f2/adclass.py
@@ -149,6 +149,12 @@ class AstroDataF2(AstroDataGemini):
         else:
             camera = self.lyot_stop()
 
+        if camera:
+            if stripID or pretty:
+                return gmu.removeComponentID(camera)
+            else:
+                return camera
+
         return self._may_remove_component(camera, stripID, pretty)
 
     # TODO: sort out the unit-handling here
@@ -384,7 +390,7 @@ class AstroDataF2(AstroDataGemini):
         # 2022-02-22:  The lyot wheel now contains filters and stops
         #  Gymnastic is required to figure out which is which.
 
-        if lyot[0:1] != "f" and lyot[0:4] != "GEMS" and lyot[0:4] != "Hart":
+        if lyot is not None and lyot[0:1] != "f" and lyot[0:4] != "GEMS" and lyot[0:4] != "Hart":
             filter3 = lyot
         else:
             filter3 = None


### PR DESCRIPTION
fixes for interpreting LYOT headers for filter name and camera on F2 data

* Check for missing LYOT while trying to parse it in determining the filter name
* Camera fix when value taken from LYOT
* Support for old LYOT header keyword LYOTPOS