### PR TITLE
Bugfix/3.1.x fixing test add illum mask inputs

### DIFF
--- a/geminidr/gnirs/tests/image/__init__.py
+++ b/geminidr/gnirs/tests/image/__init__.py
@@ -1,0 +1,1 @@
+CREATED_INPUTS_PATH_FOR_TESTS = "./dragons_test_inputs/geminidr/gnirs/image/"

--- a/geminidr/gnirs/tests/image/__init__.py
+++ b/geminidr/gnirs/tests/image/__init__.py
@@ -1,1 +1,0 @@
-CREATED_INPUTS_PATH_FOR_TESTS = "./dragons_test_inputs/geminidr/gnirs/image/"

--- a/geminidr/gnirs/tests/image/test_add_illum_mask.py
+++ b/geminidr/gnirs/tests/image/test_add_illum_mask.py
@@ -30,7 +30,7 @@ def test_add_illum_mask(filename, result, change_working_dir, path_to_inputs):
         ad = astrodata.open(download_from_archive(filename))
     with change_working_dir():
         p = GNIRSImage([ad])
-        p.prepare(bad_wcs="ignore")
+        p.prepare()  # bad_wcs="ignore")
         adout = p.addIllumMaskToDQ().pop()
         y, x = np.unravel_index(adout[0].mask.argmin(), adout[0].shape)
         # Get the middle unmasked pixel on the bottom row

--- a/geminidr/gnirs/tests/image/test_add_illum_mask.py
+++ b/geminidr/gnirs/tests/image/test_add_illum_mask.py
@@ -24,11 +24,11 @@ DATASETS = (("N20110627S0031.fits", (625, 445)),  # ShortBlue, Wings, off-centre
 @pytest.mark.remote_data
 @pytest.mark.parametrize("filename,result", DATASETS)
 def test_add_illum_mask(filename, result, change_working_dir, path_to_inputs):
+    if filename.startswith("N2022"):
+        ad = astrodata.open(os.path.join(path_to_inputs, filename))
+    else:
+        ad = astrodata.open(download_from_archive(filename))
     with change_working_dir():
-        if filename.startswith("N2022"):
-            ad = astrodata.open(os.path.join(path_to_inputs, filename))
-        else:
-            ad = astrodata.open(download_from_archive(filename))
         p = GNIRSImage([ad])
         p.prepare(bad_wcs="ignore")
         adout = p.addIllumMaskToDQ().pop()

--- a/geminidr/gnirs/tests/image/test_add_illum_mask.py
+++ b/geminidr/gnirs/tests/image/test_add_illum_mask.py
@@ -20,7 +20,6 @@ DATASETS = (("N20110627S0031.fits", (625, 445)),  # ShortBlue, Wings, off-centre
             )
 
 
-@pytest.mark.skip("MUST WORK")
 @pytest.mark.gnirs
 @pytest.mark.remote_data
 @pytest.mark.parametrize("filename,result", DATASETS)


### PR DESCRIPTION
Fixed missing module __init__.py that caused the wrong path to be generated for test input location.  Removing bad_wcs argument that isn't valid.