### PR TITLE
more flexible matching of IFU tag for new GNIRS SLIT header values

### DIFF
--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -54,7 +54,7 @@ class AstroDataGnirs(AstroDataGemini):
             slit = self.phu.get('SLIT', '').lower()
             grat = self.phu.get('GRATING', '')
             prism = self.phu.get('PRISM', '')
-            if slit == 'ifu':
+            if 'ifu' in slit:
                 tags.add('IFU')
             elif ('arcsec' in slit or 'pin' in slit) and 'mm' in grat:
                 if 'MIR' in prism:

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -166,5 +166,11 @@ def test_ra_dec_from_text():
     assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
+@pytest.mark.dragons_remote_data
+@pytest.mark.parametrize("ad", ["N20220918S0040.fits"], indirect=True)
+def test_ifu_tag(ad):
+    assert("IFU" in ad.tags)
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This allows IFU tagging of data where IFU (case insensitive) is present in the SLIT keyword for GNIRS data, rather than requiring an exact match.  SLIT keywords were enriched back in 2007 so we need to just substring match.