### PR TITLE
GNIRS IFU handling for focal_plane_mask descriptor

### DIFF
--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -350,6 +350,10 @@ class AstroDataGnirs(AstroDataGemini):
                 fpm = slit
             elif "XD" in decker:
                 fpm = "{}XD".format(slit)
+            elif "HR-IFU" in slit and "HR-IFU" in decker:
+                fpm = "HR-IFU"
+            elif "LR-IFU" in slit and "LR-IFU" in decker:
+                fpm = "LR-IFU"
             elif "IFU" in slit and "IFU" in decker:
                 fpm = "IFU"
             elif "Acq" in slit and "Acq" in decker:

--- a/gemini_instruments/gnirs/adclass.py
+++ b/gemini_instruments/gnirs/adclass.py
@@ -54,7 +54,7 @@ class AstroDataGnirs(AstroDataGemini):
             slit = self.phu.get('SLIT', '').lower()
             grat = self.phu.get('GRATING', '')
             prism = self.phu.get('PRISM', '')
-            if slit == 'ifu':
+            if 'ifu' in slit:
                 tags.add('IFU')
             elif ('arcsec' in slit or 'pin' in slit) and 'mm' in grat:
                 if 'MIR' in prism:

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -166,10 +166,20 @@ def test_ra_dec_from_text():
     assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
+# TODO: HR-IFU data doesn't exist yet, add one when available
+EXPECTED_FPMS = [
+    ('N20220918S0040.fits', "LR-IFU"),
+    ("S20061213S0131.fits", "IFU")
+]
+
+
 @pytest.mark.dragons_remote_data
-@pytest.mark.parametrize("ad", ["N20220918S0040.fits"], indirect=True)
-def test_ifu_tag(ad):
+@pytest.mark.parametrize("filename,expected_fpm", EXPECTED_FPMS)
+def test_ifu_fpm(filename, expected_fpm):
+    path = astrodata.testing.download_from_archive(filename)
+    ad = astrodata.open(path)
     assert("IFU" in ad.tags)
+    assert(ad.focal_plane_mask(pretty=True) == expected_fpm)
 
 
 if __name__ == "__main__":

--- a/gemini_instruments/gnirs/tests/test_gnirs.py
+++ b/gemini_instruments/gnirs/tests/test_gnirs.py
@@ -166,5 +166,11 @@ def test_ra_dec_from_text():
     assert ad.target_dec() == pytest.approx(24.345277777777778)
 
 
+@pytest.mark.dragons_remote_data
+@pytest.mark.parametrize("ad", ["N20220918S0040.fits"], indirect=True)
+def test_ifu_tag(ad):
+    assert("IFU" in ad.tags)
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
IFU tagging when IFU is a substring of the SLIT keyword value
HR-IFU and LR-IFU options added to focal_plane_mask descriptor when pretty=True - will be used by Archive GNIRS table
