### PR TITLE
raising more helpful error if we pass None to a textinput interactive

### DIFF
--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -178,6 +178,9 @@ class extractSpectraConfig(config.Config):
 def check_section(value):
     # Check for validity of a section string
     subsections = value.split(',')
+    if len(subsections) == 1 and subsections[0] == '':
+        # no Sections
+        return True
     for i, (x1, x2) in enumerate(s.split(':') for s in subsections):
         try:
             x1 = int(x1)
@@ -204,7 +207,7 @@ class findAperturesConfig(config.Config):
     percentile = config.RangeField("Percentile to determine signal for each spatial pixel",
                                    int, 80, min=1, max=100, optional=True, inclusiveMax=True)
     section = config.Field("Pixel section(s) for measuring the spatial profile",
-                           str, None, optional=True, check=check_section)
+                           str, "", optional=False, check=check_section)
     min_sky_region = config.RangeField("Minimum number of contiguous pixels "
                                        "between sky lines", int, 50, min=1)
     min_snr = config.RangeField("Signal-to-noise ratio threshold for peak detection",

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -635,29 +635,33 @@ class PrimitiveVisualizer(ABC):
                     else:
                         title = _title_from_field(field)
                     val = self.ui_params.values.get(key, "")
-                    widget = TextInput(title=title,
-                                       min_width=100,
-                                       max_width=256,
-                                       width_policy="fit",
-                                       placeholder=params.placeholders[key]
-                                       if key in params.placeholders else None,
-                                       value=val)
+                    if val is None:
+                        # TextInput can't handle None value
+                        raise ValueError(f"None value cannot be expressed in UI and {key} parameter came in as None")
+                    else:
+                        widget = TextInput(title=title,
+                                           min_width=100,
+                                           max_width=256,
+                                           width_policy="fit",
+                                           placeholder=params.placeholders[key]
+                                           if key in params.placeholders else None,
+                                           value=val)
 
-                    class TextHandler:
-                        def __init__(self, key, extras, fn):
-                            self.key = key
-                            self.extras = extras
-                            self.fn = fn
+                        class TextHandler:
+                            def __init__(self, key, extras, fn):
+                                self.key = key
+                                self.extras = extras
+                                self.fn = fn
 
-                        def handler(self, name, old, new):
-                            self.extras[self.key] = new
-                            if reinit_live and self.fn is not None:
-                                self.fn()
+                            def handler(self, name, old, new):
+                                self.extras[self.key] = new
+                                if reinit_live and self.fn is not None:
+                                    self.fn()
 
-                    widget.on_change("value", TextHandler(key, self.extras, lambda: self.reconstruct_points()).handler)
+                        widget.on_change("value", TextHandler(key, self.extras, lambda: self.reconstruct_points()).handler)
 
-                    self.widgets[key] = widget
-                    widgets.append(widget)
+                        self.widgets[key] = widget
+                        widgets.append(widget)
         return widgets
 
     def slider_handler_factory(self, key, reinit_live=False):


### PR DESCRIPTION

 * change findApertures section to not optional and default to ""
 * in interactive text input widget for a paramenter, raises a ValueError with a helpful exception if we are sent a None, since the text input can't handle those and it would be ambiguous with ""