### PR TITLE
Fix #396, display primitive doesn't need BPM or illum mask.

### DIFF
--- a/geminidr/core/primitives_visualize.py
+++ b/geminidr/core/primitives_visualize.py
@@ -123,7 +123,8 @@ class Visualize(PrimitivesBASE):
                         threshold = None
                     else:
                         # addDQ operates in place so deepcopy to preserve input
-                        ad = self.addDQ([deepcopy(ad)])[0]
+                        ad = self.addDQ([deepcopy(ad)],
+                                add_illum_mask=False, static_bpm = None)[0]
                         copied = True
 
             if remove_bias:


### PR DESCRIPTION
It looked like #396 was an easy fix waiting to be picked up. Hoping this PR is an easy review and helpful.

Let me know if it seems better to use a mocking library; I didn't see any in use in the project and worked without it.

Also worth nothing: I did use TDD on this, that is to say, I know that this new test fails without the corresponding update to `Visualize.display`. However, the test in this design could stop being effective if parameter defaults are changed/methods are renamed/etc. If there's a better approach to testing this, I would be happy to change the test accordingly. It also may not be an important regression to keep as a test, if CI speed is an issue.

Cheers!