### PR TITLE
distortionCorrect memory fix

### DIFF
--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -1808,8 +1808,11 @@ class Spect(Resample):
                         # In further refactoring, the mosaic WCS should get added
                         # at an earlier stage, separately from resampling.
                         log.warning('Image will be mosaicked.')
+                        # TODO: Analyse this step of the algorithm (After outputs are added to 
+                        # end of list, it is safe to delete current element of list )
                         adinputs.extend(self.mosaicDetectors([ad]))
-                        # adoutputs.extend(self.mosaicDetectors([ad]))
+                        del adinputs[i]
+                        
                     continue
 
                 # Do all the extension WCSs contain a mosaic frame, allowing us to

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -1801,8 +1801,7 @@ class Spect(Resample):
                     if 'sq' in self.mode or do_cal == 'force':
                         fail = True
                     elif len(ad) == 1:
-                        ad
-                        #adoutputs.append(ad)
+
                         adinputs[i] = ad_out
                     else:
                         # In further refactoring, the mosaic WCS should get added


### PR DESCRIPTION
I tried implementing the suggestions in #429 
Just got introduced to this repository so might have made some inaccurate assumptions while refactoring code.

My thought process:
1) Replacing the AD input with the output in `adinputs` works generally using `adinputs[i] = ad_out` after enumerating adinputs
2) It fails in one case, where the image is a mosiac and therefore multiple ADs are extended to
the end of the list. In this case, we need to delete the current element in the adinputs list after it is processed by `mosaicDetectors`  as in [here](https://github.com/phanicode/DRAGONS/blob/364f0ebde37e8d6fab0235cf4f412de04ba6ad0c/geminidr/core/primitives_spect.py#L1814)

Side note: I tried type-checking `adinput` as it had a default None parameter in the function declaration.
