### PR TITLE
Avoid conda race conditions within a Jenkins test run

### DIFF
--- a/.jenkins/scripts/download_and_install_anaconda.sh
+++ b/.jenkins/scripts/download_and_install_anaconda.sh
@@ -32,6 +32,7 @@ fi
 
 echo ${PATH}
 which conda
+conda clean -i -t -y  # in case of corrupt package cache from previous run
 conda update --quiet conda
 # These 2 channels need removing if testing old branches has reinstated them:
 conda config --remove channels http://ssb.stsci.edu/astroconda || :

--- a/.jenkins/scripts/setup_agent.sh
+++ b/.jenkins/scripts/setup_agent.sh
@@ -3,17 +3,8 @@
 
 set -eux
 
-# Cleanup
+pwd
 git clean -fxd
-mkdir plots reports
-if [[ -n "${DRAGONS_TEST_OUTPUTS-}" ]]; then
-    if [[ -d "${DRAGONS_TEST_OUTPUTS}" ]]; then
-        echo "Cleaning previous test results in ${DRAGONS_TEST_OUTPUTS}"
-        rm -r ${DRAGONS_TEST_OUTPUTS}
-    else
-        echo "Skip delete unexisting ${DRAGONS_TEST_OUTPUTS}"
-    fi
-fi
 
 source .jenkins/scripts/download_and_install_anaconda.sh
 

--- a/.jenkins/scripts/setup_dirs.sh
+++ b/.jenkins/scripts/setup_dirs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+
+set -eux
+
+# Cleanup
+pwd
+git clean -fxd
+mkdir plots reports
+if [[ -n "${DRAGONS_TEST_OUT-}" ]]; then
+    if [[ -d "${DRAGONS_TEST_OUT}" ]]; then
+        echo "Cleaning previous test results in ${DRAGONS_TEST_OUT}"
+        rm -r ${DRAGONS_TEST_OUT}
+    else
+        echo "Skip deletion of inexistent ${DRAGONS_TEST_OUT}"
+    fi
+else
+    echo "DRAGONS_TEST_OUT is not set, so not deleting it"
+fi
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
         skipDefaultCheckout(true)
         buildDiscarder(logRotator(numToKeepStr: '5'))
         timestamps()
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
     }
 
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
 
     environment {
         MPLBACKEND = "agg"
+        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
     }
 
     stages {
@@ -46,6 +47,29 @@ pipeline {
         stage ("Prepare"){
             steps{
                 sendNotifications 'STARTED'
+            }
+        }
+
+        stage('Pre-install') {
+            agent { label "conda" }
+            environment {
+                TMPDIR = "${env.WORKSPACE}/.tmp/conda/"
+            }
+            steps {
+                echo "Update the Conda base install for all on-line nodes"
+                checkout scm
+                sh '.jenkins/scripts/setup_agent.sh'
+                echo "Create a trial Python 3.10 env, to cache new packages"
+                sh 'tox -e py310-noop -v -r -- --basetemp=${DRAGONS_TEST_OUT} ${TOX_ARGS}'
+            }
+            post {
+                always {
+                    echo "Deleting conda temp workspace ${env.WORKSPACE}"
+                    cleanWs()
+                    dir("${env.WORKSPACE}@tmp") {
+                      deleteDir()
+                    }
+                }
             }
         }
 
@@ -59,7 +83,6 @@ pipeline {
                     }
                     environment {
                         MPLBACKEND = "agg"
-                        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                         DRAGONS_TEST_OUT = "unit_tests_outputs/"
                         TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                         TMPDIR = "${env.WORKSPACE}/.tmp/unit/"
@@ -67,7 +90,7 @@ pipeline {
                     steps {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
-                        sh '.jenkins/scripts/setup_agent.sh'
+                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests with Python 3.10"
                         sh 'tox -e py310-unit -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/unittests_results.xml ${TOX_ARGS}'
                         echo "Reportint coverage to CodeCov"
@@ -97,7 +120,6 @@ pipeline {
                     agent { label "centos7" }
                     environment {
                         MPLBACKEND = "agg"
-                        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                         DRAGONS_TEST_OUT = "./integ_tests_outputs/"
                         TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                         TMPDIR = "${env.WORKSPACE}/.tmp/integ/"
@@ -106,7 +128,7 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         echo "${env.PATH}"
-                        sh '.jenkins/scripts/setup_agent.sh'
+                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Integration tests"
                         sh 'tox -e py310-integ -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/integration_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
@@ -131,7 +153,6 @@ pipeline {
                     agent { label "master" }
                     environment {
                         MPLBACKEND = "agg"
-                        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                         DRAGONS_TEST_OUT = "regression_tests_outputs"
                         TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                         TMPDIR = "${env.WORKSPACE}/.tmp/regr/"
@@ -140,7 +161,7 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         echo "${env.PATH}"
-                        sh '.jenkins/scripts/setup_agent.sh'
+                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Regression tests"
                         sh 'tox -e py310-reg -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/regression_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
@@ -171,7 +192,6 @@ pipeline {
             agent { label "master" }
             environment {
                 MPLBACKEND = "agg"
-                PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                 DRAGONS_TEST_OUT = "f2_tests_outputs"
                 TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                 TMPDIR = "${env.WORKSPACE}/.tmp/f2/"
@@ -179,7 +199,7 @@ pipeline {
             steps {
                 echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                 checkout scm
-                sh '.jenkins/scripts/setup_agent.sh'
+                sh '.jenkins/scripts/setup_dirs.sh'
                 echo "Running tests"
                 sh 'tox -e py310-f2 -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/f2_results.xml ${TOX_ARGS}'
                 echo "Reporting coverage"
@@ -209,7 +229,6 @@ pipeline {
             agent { label "master" }
             environment {
                 MPLBACKEND = "agg"
-                PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                 DRAGONS_TEST_OUT = "gsaoi_tests_outputs"
                 TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                 TMPDIR = "${env.WORKSPACE}/.tmp/gsaoi/"
@@ -217,7 +236,7 @@ pipeline {
             steps {
                 echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                 checkout scm
-                sh '.jenkins/scripts/setup_agent.sh'
+                sh '.jenkins/scripts/setup_dirs.sh'
                 echo "Running tests"
                 sh 'tox -e py310-gsaoi -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gsaoi_results.xml ${TOX_ARGS}'
                 echo "Reporting coverage"
@@ -247,7 +266,6 @@ pipeline {
             agent { label "master" }
             environment {
                 MPLBACKEND = "agg"
-                PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                 DRAGONS_TEST_OUT = "niri_tests_outputs"
                 TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                 TMPDIR = "${env.WORKSPACE}/.tmp/niri/"
@@ -255,7 +273,7 @@ pipeline {
             steps {
                 echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                 checkout scm
-                sh '.jenkins/scripts/setup_agent.sh'
+                sh '.jenkins/scripts/setup_dirs.sh'
                 echo "Running tests"
                 sh 'tox -e py310-niri -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/niri_results.xml ${TOX_ARGS}'
                 echo "Reporting coverage"
@@ -285,7 +303,6 @@ pipeline {
             agent { label "master" }
             environment {
                 MPLBACKEND = "agg"
-                PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                 DRAGONS_TEST_OUT = "gnirs_tests_outputs"
                 TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                 TMPDIR = "${env.WORKSPACE}/.tmp/gnirs/"
@@ -293,7 +310,7 @@ pipeline {
             steps {
                 echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                 checkout scm
-                sh '.jenkins/scripts/setup_agent.sh'
+                sh '.jenkins/scripts/setup_dirs.sh'
                 echo "Running tests"
                 sh 'tox -e py310-gnirs -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gnirs_results.xml ${TOX_ARGS}'
                 echo "Reporting coverage"
@@ -323,7 +340,6 @@ pipeline {
             agent { label "master" }
             environment {
                 MPLBACKEND = "agg"
-                PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                 DRAGONS_TEST_OUT = "wavecal_tests_outputs"
                 TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                 TMPDIR = "${env.WORKSPACE}/.tmp/wavecal/"
@@ -331,7 +347,7 @@ pipeline {
             steps {
                 echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                 checkout scm
-                sh '.jenkins/scripts/setup_agent.sh'
+                sh '.jenkins/scripts/setup_dirs.sh'
                 echo "Running tests"
                 sh 'tox -e py310-wavecal -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/wavecal_results.xml ${TOX_ARGS}'
                 echo "Reporting coverage"
@@ -364,7 +380,6 @@ pipeline {
                     agent { label "master" }
                     environment {
                         MPLBACKEND = "agg"
-                        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                         DRAGONS_TEST_OUT = "gmosls_tests_outputs"
                         TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                         TMPDIR = "${env.WORKSPACE}/.tmp/gmosls/"
@@ -372,7 +387,7 @@ pipeline {
                     steps {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
-                        sh '.jenkins/scripts/setup_agent.sh'
+                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
                         sh 'tox -e py310-gmosls -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gmosls_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
@@ -402,7 +417,6 @@ pipeline {
                     agent { label "master" }
                     environment {
                         MPLBACKEND = "agg"
-                        PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
                         DRAGONS_TEST_OUT = "regression_tests_outputs"
                         TOX_ARGS = "astrodata geminidr gemini_instruments gempy recipe_system"
                         TMPDIR = "${env.WORKSPACE}/.tmp/slow/"
@@ -411,7 +425,7 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         echo "${env.PATH}"
-                        sh '.jenkins/scripts/setup_agent.sh'
+                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Slow tests"
                         sh 'tox -e py310-slow -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/slow_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}-{unit,f2,gsaoi,niri,gnirs,gmosls,integ,reg,slow}
+    py{37,38,39,310,311}-{noop,unit,f2,gsaoi,niri,gnirs,gmosls,integ,reg,slow}
     codecov
     check
     docs-{astrodata}
@@ -53,8 +53,10 @@ conda_channels =
     conda-forge
 conda_create_args =
     --override-channels
+    --experimental=lock
 conda_install_args =
     --override-channels
+    --experimental=lock
 extras =
     test
     docs: docs
@@ -71,6 +73,7 @@ commands =
     which pytest
     pip install git+https://github.com/GeminiDRSoftware/AstroFaker#egg=AstroFaker
     conda list
+    noop: python -c "pass"  # just install deps & ensure python runs
     unit: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "not integration_test and not gmosls and not f2 and not f2ls and not f2image and not gsaoi and not gsaoiimage and not niri and not nirils and not niriimage and not gnirs and not gnirsls and not gnirsimage and not wavecal and not regression and not slow" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}
     integ: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "integration_test and not slow" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}
     gmosls: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "gmosls and not slow and not wavecal" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}


### PR DESCRIPTION
Our Jenkins pipeline for testing DRAGONS seems to have been constructed with no regard for collisions between conda commands in parallel stages. In the past it has mostly worked anyway, but we have seen an increasing number of obscure failures in recent months, some of which do look very much like the result of multiple tests trying to update the Anaconda base installation at the same time, or trying to download the same package update at the same time. It is unclear why these problems have started occurring more often [update: see 4 Jul], but it could be due to changes in the behaviour of conda, or timing issues, including network glitches (which are another source of problems; see ITOPS-8891 on JIRA).

This PR reorganizes the pipeline in `master` a bit, so that the Anaconda/Miniforge base is updated by a single `Pre-install` stage and any package updates get downloaded there before the parallel test stages are executed. The package cache also gets cleaned out at the start (as in my `conda_err` branch), because we have seen numerous cases of it getting corrupted since April, which otherwise breaks subsequent test runs, until someone intervenes manually. This precuation could be a mixed blessing, since it could lead to more package downloads that are potential points of failure, but at least those failures should be recoverable, whereas a corrupt package cache currently leaves Jenkins defunct.

Unfortunately the new stage currently adds about 15 minutes to the execution time, mostly due to an extra `conda create` of the test env (rather than `conda update` in the base), but someone can look into optimizing that later -- currently I'm just trying to make Jenkins stable again. I think this overhead is larger than normal at the moment, because we've had to disallow the latest `astropy=5.3` due to an `NDData` bug, which makes the solver slower.

Note that creation of a test env in `Pre-install` (the slow bit) might not be essential, because I think the corruption of downloaded packages is temporary, ie. at some point the last conda invocation finishes overwriting the tarball and it is then valid again, as long as none of the test stages have tried to use it in the meantime. Consistent with this, I have seen some tests pass after an error about the astropy package being corrupt. Better safe than sorry though...

I have squashed most of the commits, to make this easier to merge into other branches, but have left the one that pre-creates the test env separate (see last para.).

This does not guarantee that simultaneous test runs on different branches won't collide, but that's less likely timing-wise and being able to run a single set reliably is a far bigger issue.

Having looked at the behaviour & overheads a bit, ~I now think we should consider using a completely separate base installation for each test stage instead~, since 1) moving from Anaconda to Miniforge has made it feasible, space- and speed-wise, 2) it turns out that the base installation overhead isn't that big compared with setting up the test env itself (especially if we have to clear out the package cache anyway) and 3) that should solve any race conditions between simultaneous test runs on different branches. Maybe I should look into that, which was less obvious when I started, but in the meantime this version should already be an improvement and the PR gives us somewhere to discuss the issue.

@KathleenLabrie, @DBerke 