### PR TITLE
Set wavecal wavelength labels relative to spectrum

### DIFF
--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -552,6 +552,25 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         return new_model
 
+    @staticmethod
+    def _get_plot_ranges(plot: figure):
+        """Get the start and end of the x and y ranges of a plot."""
+        x_range = plot.x_range
+        y_range = plot.y_range
+
+        ranges = {
+            "x": (x_range.start, x_range.end),
+            "y": (y_range.start, y_range.end),
+        }
+
+        return ranges
+
+    def plot_range(self):
+        return self._get_plot_ranges(self.p_spectrum)
+
+    def plot_range_refplot(self):
+        return self._get_plot_ranges(self.p_refplot)
+
     def label_height(self, x):
         """Provide a location for a wavelength label identifying a line.
 

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -332,7 +332,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
         # for the text, which is the center of the text, so it's inverse the
         # common axes logic. And also not standard for, e.g., image coordinates
         # in most software.
-        y_offset = -15
+        y_offset = -5
         text_align = 'left'
 
         if self.absorption:
@@ -614,13 +614,34 @@ class WavelengthSolutionPanel(Fit1DPanel):
         float/list : appropriate y value(s) for writing a label
         """
         try:
-            return [
-                self.spectrum.data["spectrum"][int(xx + 0.5)]
-                for xx in x
-            ]
+            iter(x)
+            single_value = False
 
         except TypeError:
-            return self.spectrum.data["spectrum"][int(x + 0.5)]
+            single_value = True
+            x = [x]
+
+        spectrum = self.spectrum.data["spectrum"]
+
+        # Get points around the line.
+        def get_nearby_points(p):
+            low = max(0, int(p - 4.5))
+            high = min(len(spectrum), int(p + 5.5))
+            return spectrum[low:high]
+
+        ranges = (
+            get_nearby_points(xx) for xx in x
+        )
+
+        heights = [
+            values.max()
+            for values in ranges
+        ]
+
+        if single_value:
+            return heights[0]
+        
+        return heights
 
     def refplot_label_height(self):
         """

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -674,16 +674,9 @@ class WavelengthSolutionPanel(Fit1DPanel):
             high = min(len(spectrum), int(p + distance + 0.5))
             return spectrum[low:high]
 
-        ranges = (
-            get_nearby_points(xx) for xx in x
-        )
-
         extrema_func = np.amin if self.absorption else np.amax
 
-        heights = [
-            extrema_func(values)
-            for values in ranges
-        ]
+        heights = [extrema_func(get_nearby_points(xx)) for xx in x]
 
         if single_value:
             return heights[0]

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -5,7 +5,6 @@ WavelengthSolutionVisualizer classes, which are used to interactively fit a
 wavelength solution to a spectrum.
 """
 import logging
-from tkinter import font
 import uuid
 
 from bisect import bisect

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -1163,7 +1163,7 @@ class WavelengthSolutionVisualizer(Fit1DVisualizer):
 
                 # spectrum update
                 spectrum = self.panels[i].spectrum
-                if self.absorption == True:
+                if self.absorption:
                     spectrum.data['spectrum'] = -this_dict["meta"]["spectrum"]
                 else:
                     spectrum.data['spectrum'] = this_dict["meta"]["spectrum"]

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -327,15 +327,28 @@ class WavelengthSolutionPanel(Fit1DPanel):
             mode="center",
         )
 
+        # Offset is in pixels in screen space (up is negative, down is
+        # positive) Technically, this is actually relative to the anchor point
+        # for the text, which is the center of the text, so it's inverse the
+        # common axes logic. And also not standard for, e.g., image coordinates
+        # in most software.
+        y_offset = -5
+        text_align = 'left'
+
+        if self.absorption:
+            y_offset = -y_offset
+            text_align = 'right'
+
         self._spectrum_line_labels = p_spectrum.text(
             x="fitted",
             y="heights",
             text="lines",
+            y_offset=y_offset,
             source=self.model.data,
             angle=0.5 * np.pi,
             text_color=self.model.mask_rendering_kwargs()["color"],
             text_baseline="middle",
-            text_align="right",
+            text_align=text_align,
             text_font_size="10pt",
         )
 
@@ -600,23 +613,14 @@ class WavelengthSolutionPanel(Fit1DPanel):
         -------
         float/list : appropriate y value(s) for writing a label
         """
-        plot_range = self.plot_range()
-        height = abs(plot_range['y'][0] - plot_range['y'][1])
-
-        if self.absorption:
-            padding = -0.05 * height
-
-        else:
-            padding = 0.25 * height
-
         try:
             return [
-                self.spectrum.data["spectrum"][int(xx + 0.5)] + padding
+                self.spectrum.data["spectrum"][int(xx + 0.5)]
                 for xx in x
             ]
 
         except TypeError:
-            return self.spectrum.data["spectrum"][int(x + 0.5)] + padding
+            return self.spectrum.data["spectrum"][int(x + 0.5)]
 
     def refplot_label_height(self):
         """

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -587,18 +587,19 @@ class WavelengthSolutionPanel(Fit1DPanel):
     def refplot_label_height(self):
         """
         Provide a location for a wavelength label identifying a line
-        in the reference spectrum plot
+        in the reference spectrum plot.
+
+        This calculates the label heights relative to lines already present in
+        the plot, and lets bokeh handle rescaling the y-axis as needed.
 
         Returns
         -------
         float/list : appropriate y value(s) for writing a label
         """
-        try:
-            height = self.p_refplot.y_range.end - self.p_refplot.y_range.start
-        except TypeError:  # range is None, plot being initialized
-            # This is calculated on the basis that bokeh pads by 5% of the
-            # data range on each side
-            height = 44 / 29 * np.nanmax(self.refplot_linelist.data["intensities"])
+        # Height relative to points in the spectrum, rather than relative to
+        # the plot.
+        height = 44 / 29 * np.nanmax(self.refplot_linelist.data["intensities"])
+
         if self.absorption:
             padding = -0.05 * height
         else:

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -625,8 +625,9 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         # Get points around the line.
         def get_nearby_points(p):
-            low = max(0, int(p - 4.5))
-            high = min(len(spectrum), int(p + 5.5))
+            distance = 5
+            low = max(0, int(p - distance + 0.5))
+            high = min(len(spectrum), int(p + distance + 0.5))
             return spectrum[low:high]
 
         ranges = (

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -327,7 +327,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
             mode="center",
         )
 
-        p_spectrum.text(
+        self._spectrum_line_labels = p_spectrum.text(
             x="fitted",
             y="heights",
             text="lines",
@@ -519,12 +519,26 @@ class WavelengthSolutionPanel(Fit1DPanel):
             p_refplot.sizing_mode = 'stretch_width'
             p_refplot.step(x='wavelengths', y='refplot_spectrum', source=self.refplot_spectrum,
                             line_width=1, color="gray", mode="center")
-            p_refplot.text(name="labels",
-                           x='wavelengths', y= 'heights', text='labels',
-                            source=self.refplot_linelist, angle=0.5 * np.pi,
-                            text_color='gray',
-                            text_baseline='middle', text_align='right',
-                            text_font_size='8pt')
+
+            # Offset is in pixels in screen space (up is negative, down is
+            # positive) Technically, this is actually relative to the anchor
+            # point for the text, which is the center of the text, so it's
+            # inverse the common axes logic. And also not standard for, e.g.,
+            # image coordinates in most software.
+            y_offset = -5 
+            text_align = 'left'
+
+            if self.absorption:
+                y_offset = -y_offset
+                text_align = 'right'
+
+            self._replot_line_labels = p_refplot.text(name="labels",
+                                                      x='wavelengths', y='intensities', text='labels',
+                                                      y_offset=y_offset,
+                                                      source=self.refplot_linelist, angle=0.5 * np.pi,
+                                                      text_color='gray',
+                                                      text_baseline='middle', text_align=text_align,
+                                                      text_font_size='8pt')
             p_refplot.y_range.on_change("start", lambda attr, old, new:
                                          self.update_refplot_label_heights())
             p_refplot.y_range.on_change("end", lambda attr, old, new:

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -678,8 +678,10 @@ class WavelengthSolutionPanel(Fit1DPanel):
             get_nearby_points(xx) for xx in x
         )
 
+        extrema_func = np.amin if self.absorption else np.amax
+
         heights = [
-            values.max()
+            extrema_func(values)
             for values in ranges
         ]
 

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -387,8 +387,12 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         # Set the initial vertical range to include some padding for labels
         label_positions = self.label_height(self.model.x)
-        y_low = np.amin(label_positions)
-        y_high = np.amax(label_positions)
+        min_line_intensity = np.amin(label_positions)
+        min_spectrum_intensity = np.amin(self.spectrum.data["spectrum"])
+        max_line_intensity = np.amax(label_positions)
+        max_spectrum_intensity = np.amax(self.spectrum.data["spectrum"])
+        y_low = min(min_line_intensity, min_spectrum_intensity)
+        y_high = max(max_line_intensity, max_spectrum_intensity)
         spectrum_range = y_high - y_low
         max_assumed_chars = 10
         text_padding = max_assumed_chars * font_size
@@ -580,8 +584,12 @@ class WavelengthSolutionPanel(Fit1DPanel):
                                                       text_font_size=f'{font_size}pt')
 
             # Set the initial vertical range to include some padding for labels
-            y_low = np.amin(self.refplot_linelist.data["intensities"])
-            y_high = np.amax(self.refplot_linelist.data["intensities"])
+            min_line_intensity = np.amin(self.refplot_linelist.data["intensities"])
+            min_spectrum_intensity = np.amin(self.refplot_spectrum.data["refplot_spectrum"])
+            max_line_intensity = np.amax(self.refplot_linelist.data["intensities"])
+            max_spectrum_intensity = np.amax(self.refplot_spectrum.data["refplot_spectrum"])
+            y_low = min(min_line_intensity, min_spectrum_intensity)
+            y_high = max(max_line_intensity, max_spectrum_intensity)
             spectrum_range = y_high - y_low
             labels = self.refplot_linelist.data["labels"]
             text_padding = max(len(x) for x in labels) * font_size

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -553,7 +553,10 @@ class WavelengthSolutionPanel(Fit1DPanel):
         return new_model
 
     def label_height(self, x):
-        """Provide a location for a wavelength label identifying a line
+        """Provide a location for a wavelength label identifying a line.
+
+        This calculates the label heights relative to lines already present in
+        the plot, and lets bokeh handle rescaling the y-axis as needed.
 
         Parameters
         ----------
@@ -564,18 +567,10 @@ class WavelengthSolutionPanel(Fit1DPanel):
         -------
         float/list : appropriate y value(s) for writing a label
         """
-        try:
-            height = (
-                self.p_spectrum.y_range.end - self.p_spectrum.y_range.start
-            )
+        # Height relative to points in the spectrum, rather than relative to
+        # the plot.
+        height = 44 / 29 * np.nanmax(self.spectrum.data['spectrum'])
 
-        except TypeError:  # range is None, plot being initialized
-            # This is calculated on the basis that bokeh pads by 5% of the
-            # data range on each side
-            # height = (44 / 29 * self.spectrum.data['spectrum'].max() -
-            #          1.1 * self.spectrum.data['spectrum'].min())
-
-            height = 44 / 29 * np.nanmax(self.spectrum.data['spectrum'])
         if self.absorption:
             padding = -0.05 * height
         else:

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -601,7 +601,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
         height = 44 / 29 * np.nanmax(self.refplot_linelist.data["intensities"])
 
         if self.absorption:
-            padding = -0.005 * height
+            padding = -0.05 * height
         else:
             padding = 0.35 * height
         heights = self.refplot_linelist.data["intensities"] + padding

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -568,7 +568,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
     def plot_range(self):
         return self._get_plot_ranges(self.p_spectrum)
 
-    def plot_range_refplot(self):
+    def refplot_range(self):
         return self._get_plot_ranges(self.p_refplot)
 
     def label_height(self, x):
@@ -586,14 +586,15 @@ class WavelengthSolutionPanel(Fit1DPanel):
         -------
         float/list : appropriate y value(s) for writing a label
         """
-        # Height relative to points in the spectrum, rather than relative to
-        # the plot.
-        height = 44 / 29 * np.nanmax(self.spectrum.data['spectrum'])
+        plot_range = self.plot_range()
+        height = abs(plot_range['y'][0] - plot_range['y'][1])
 
         if self.absorption:
             padding = -0.05 * height
+
         else:
             padding = 0.25 * height
+
         try:
             return [
                 self.spectrum.data["spectrum"][int(xx + 0.5)] + padding
@@ -615,14 +616,15 @@ class WavelengthSolutionPanel(Fit1DPanel):
         -------
         float/list : appropriate y value(s) for writing a label
         """
-        # Height relative to points in the spectrum, rather than relative to
-        # the plot.
-        height = 44 / 29 * np.nanmax(self.refplot_linelist.data["intensities"])
+        plot_range = self.refplot_range()
+        height = abs(plot_range['y'][0] - plot_range['y'][1])
 
         if self.absorption:
             padding = -0.05 * height
+
         else:
-            padding = 0.35 * height
+            padding = 0.25 * height
+
         heights = self.refplot_linelist.data["intensities"] + padding
         return heights
 

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -579,10 +579,6 @@ class WavelengthSolutionPanel(Fit1DPanel):
                                                       text_color='gray',
                                                       text_baseline='middle', text_align=text_align,
                                                       text_font_size=f'{font_size}pt')
-            p_refplot.y_range.on_change("start", lambda attr, old, new:
-                                         self.update_refplot_label_heights())
-            p_refplot.y_range.on_change("end", lambda attr, old, new:
-                                         self.update_refplot_label_heights())
 
             # Set the initial vertical range to include some padding for labels
             y_low = np.amin(self.refplot_linelist.data["intensities"])
@@ -731,12 +727,6 @@ class WavelengthSolutionPanel(Fit1DPanel):
                 self.new_line_marker.data["y"][1] = self.new_line_marker.data["y"][0] - lheight
             else:
                 self.new_line_marker.data["y"][1] = self.new_line_marker.data["y"][0] + lheight
-
-    def update_refplot_label_heights(self):
-        """Simple callback to move the labels if the reference spectrum panel is resized"""
-        # This is now defunct.
-        logging.warning("update_refplot_label_heights called, but is defunct")
-        return
 
     # I could put the extra stuff in a second listener but the name of this
     # is generic, so let's just super() it and then do the extra stuff
@@ -1196,7 +1186,6 @@ class WavelengthSolutionVisualizer(Fit1DVisualizer):
                             'labels': ["{:.2f}".format(w) for w in wlengths]
                         }
                     )
-                    self.panels[i].update_refplot_label_heights()
                     self.panels[i].update_refplot_name(this_dict["meta"]["refplot_name"])
                     self.panels[i].reset_view()
                 except (AttributeError, KeyError):

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -601,7 +601,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
         height = 44 / 29 * np.nanmax(self.refplot_linelist.data["intensities"])
 
         if self.absorption:
-            padding = -0.05 * height
+            padding = -0.005 * height
         else:
             padding = 0.35 * height
         heights = self.refplot_linelist.data["intensities"] + padding

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -1133,7 +1133,7 @@ class WavelengthSolutionVisualizer(Fit1DVisualizer):
             for key in params.reinit_params:
                 # The following is to add a special subset of UI widgets
                 # for fine-tuning the generated ATRAN linelist
-                if type(key) == dict and "atran_linelist_pars" in key:
+                if isinstance(key, dict) and "atran_linelist_pars" in key:
                     linelist_reinit_params = key.get("atran_linelist_pars")
                     params.reinit_params.remove(key)
                     params.reinit_params = params.reinit_params+linelist_reinit_params

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -332,7 +332,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
         # for the text, which is the center of the text, so it's inverse the
         # common axes logic. And also not standard for, e.g., image coordinates
         # in most software.
-        y_offset = -5
+        y_offset = -15
         text_align = 'left'
 
         if self.absorption:
@@ -663,7 +663,9 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
     def update_refplot_label_heights(self):
         """Simple callback to move the labels if the reference spectrum panel is resized"""
-        self.refplot_linelist.data['heights'] = self.refplot_label_height()
+        # This is now defunct.
+        logging.warning("update_refplot_label_heights called, but is defunct")
+        return
 
     # I could put the extra stuff in a second listener but the name of this
     # is generic, so let's just super() it and then do the extra stuff

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -884,7 +884,7 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
     def clear_all_lines(self):
         """
-        Called when the user clicks the "Clear all ines" button. Deletes
+        Called when the user clicks the "Clear all lines" button. Deletes
         all identified lines, performs a new fit.
         """
         self.model.data.data = {col: [] for col, values in self.model.data.data.items()}


### PR DESCRIPTION
Previously, the wavelength calibration set the label position based on, depending on the circumstances, the plot's y-axis or the spectrum's heights. This takes the peak heights and applies a padding to place the text.

This hopefully solve a problem with the bokeh server stalling when wavelengths are added to the plot by a user or the calibrator.