### PR TITLE
findApertures input fixes

### DIFF
--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -245,7 +245,7 @@ class findAperturesConfig(config.Config):
     use_snr = config.Field("Use signal-to-noise ratio rather than data in "
                            "collapsed profile?", bool, True)
     threshold = config.RangeField("Threshold for automatic width determination",
-                                  float, 0.1, min=0, max=1)
+                                  float, 0.1, min=0, max=1, fix_end_to_max=True)
     interactive = config.Field("Use interactive interface", bool, False)
     max_separation = config.RangeField("Maximum separation from target location (arcsec)",
                                        int, None, min=1, inclusiveMax=True, optional=True)

--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -534,7 +534,8 @@ class traceAperturesConfig(config.core_1Dfitting_config):
     max_missed = config.RangeField("Maximum number of steps to miss before a line is lost",
                                    int, 5, min=0)
     max_shift = config.RangeField("Maximum shift per pixel in line position",
-                                  float, 0.05, min=0.001, max=0.1, inclusiveMax=True)
+                                  float, 0.05, min=0.001, max=0.1, inclusiveMax=True,
+                                  fix_end_to_max=True)
     nsum = config.RangeField("Number of lines to sum",
                              int, 10, min=1)
     step = config.RangeField("Step in rows/columns for tracing",

--- a/geminidr/interactive/fit/aperture.py
+++ b/geminidr/interactive/fit/aperture.py
@@ -1238,6 +1238,11 @@ class FindSourceAperturesVisualizer(PrimitiveVisualizer):
         # set to None.
         self.ui_params.fields["max_separation"].optional = False
 
+        # Make the threshold field fit the proper range (0 - 1, not 0 - 10).
+        self.ui_params.fields["threshold"].min = 0
+        self.ui_params.fields["threshold"].max = 1
+
+
     def add_aperture(self):
         """
         Add a new aperture in the middle of the current display area.

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -820,6 +820,8 @@ class PrimitiveVisualizer(ABC):
                         handler=slider_handler,
                         add_spacer=add_spacer,
                         hide_textbox=key in hide_textbox,
+                        fix_end_to_max=field.fix_end_to_max,
+                        fix_start_to_min=field.fix_start_to_min,
                     )
 
                     self.widgets[key] = widget.children[0]
@@ -1000,6 +1002,9 @@ def build_text_slider(
     is_float=None,
     add_spacer=False,
     hide_textbox=False,
+    *,
+    fix_start_to_min=False,
+    fix_end_to_max=False,
 ):
     """
     Make a slider widget to use in the bokeh interface.
@@ -1034,6 +1039,12 @@ def build_text_slider(
         False)
     hide_textbox : bool
         If True, don't show a text box and just use a slider (default False)
+    fix_start_to_min : bool, optional, keyword-only
+        If True, the start value of the slider will be fixed to the min_value
+        (default False).
+    fix_end_to_max : bool, optional, keyword-only
+        If True, the end value of the slider will be fixed to the max_value
+        (default False).
 
     Returns
     -------
@@ -1060,6 +1071,7 @@ def build_text_slider(
             msg="max_value must be greater than 0 or None. Setting to None."
         )
 
+    # TODO: These probably shouldn't default to 10 for the max value.
     if value is None:
         # If the value is None/Falsey, set to a default value
         start = min_value or 0
@@ -1071,6 +1083,13 @@ def build_text_slider(
         start = min(value, min_value or 0)
         end = max(value, max_value or 2 * value, 10)
         slider_kwargs = {"value": value, "show_value": True}
+
+    # Fix the start/end values to the min/max values if requested
+    if fix_start_to_min:
+        start = min_value
+
+    if fix_end_to_max:
+        end = max_value
 
     # trying to convince int-based sliders to behave
     if is_float is None:
@@ -2216,6 +2235,7 @@ class UIParameters:
 
         :reinit_params: list
             List of names of configuration fields to show in the reinit panel
+
         :title_overrides: dict
             Dictionary of overrides for labeling the fields in the UI
 

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -915,22 +915,31 @@ class PrimitiveVisualizer(ABC):
                             stylesheets=dragons_styles(),
                         )
 
-
                         class TextHandler:
-                            def __init__(self, key, extras, fn):
+                            def __init__(self, key, extras, fn, reinit_live):
                                 self.key = key
                                 self.extras = extras
                                 self.fn = fn
+                                self.reinit_live = reinit_live
 
                             def handler(self, name, old, new):
                                 self.extras[self.key] = new
                                 if self.reinit_live and self.fn is not None:
                                     self.fn()
 
-                        widget.on_change("value", TextHandler(key, self.extras, lambda: self.reconstruct_points()).handler)
+                        widget.on_change(
+                            "value",
+                            TextHandler(
+                                key,
+                                self.extras,
+                                self.reconstruct_points,
+                                self.reinit_live
+                            ).handler
+                        )
 
                         self.widgets[key] = widget
                         widgets.append(widget)
+
         return widgets
 
     def slider_handler_factory(self, key):

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -801,7 +801,9 @@ class PrimitiveVisualizer(ABC):
 
                 if hasattr(field, "min"):
                     is_float = field.dtype is not int
-                    step = 0.1 if is_float else 1
+
+                    # Step is handled in the slider factory.
+                    step = None 
 
                     slider_handler = self.slider_handler_factory(key)
 
@@ -1110,7 +1112,7 @@ def build_text_slider(
 
     if step is None:
         if is_float:
-            step = 0.1
+            step = min(0.1, (end - start) / 100)
         else:
             step = 1
 

--- a/gempy/library/config/rangeField.py
+++ b/gempy/library/config/rangeField.py
@@ -38,7 +38,41 @@ class RangeField(Field):
     supportedTypes = set((int, float))
 
     def __init__(self, doc, dtype, default=None, optional=False,
-                 min=None, max=None, inclusiveMin=True, inclusiveMax=False):
+                 min=None, max=None, inclusiveMin=True, inclusiveMax=False,
+                 *, fix_start_to_min=False, fix_end_to_max=False):
+        """Initialize a RangeField object.
+
+        Parameters
+        ----------
+        doc : str
+            The documentation string for the RangeField object.
+        dtype : type
+            The data type of the RangeField.
+        default : optional
+            The default value for the RangeField (default: None).
+        optional : bool
+            Whether the RangeField is optional (default: False).
+        min : optional
+            The minimum value of the RangeField (default: None).
+        max : optional
+            The maximum value of the RangeField (default: None).
+        inclusiveMin : bool
+            Whether the minimum value is inclusive (default: True).
+        inclusiveMax : bool
+            Whether the maximum value is inclusive (default: False).
+        fix_start_to_min : bool
+            Whether to fix the start value to the minimum value (default: False).
+        fix_end_to_max : bool
+            Whether to fix the end value to the maximum value (default: False).
+
+        Raises
+        ------
+        ValueError
+            If the dtype is not supported or if both min and max are None.
+        ValueError
+            If min is greater than max or if min equals max and both are not inclusive.
+
+        """
         if dtype not in self.supportedTypes:
             raise ValueError("Unsupported RangeField dtype %s" % (_typeStr(dtype)))
         source = getStackFrame()
@@ -53,6 +87,8 @@ class RangeField(Field):
 
         self.min = min
         self.max = max
+        self.fix_start_to_min = fix_start_to_min
+        self.fix_end_to_max = fix_end_to_max
 
         self.rangeString = "%s%s,%s%s" % \
             (("[" if inclusiveMin else "("),


### PR DESCRIPTION
# Slider ranges can now be explicitly set

`config.RangeField` had no means of communicating a desired slider range when constructing a slider. Frequently, the slider should only span the min/max range, but `PrimitiveVisualizer.build_text_slider` would default to `end=10` if the maximum value or twice the value was less than 10. Precisely, for situations where the initial value is provided ([interactive.py line 1082](https://github.com/GeminiDRSoftware/DRAGONS/blob/1f65fbf60a7e780dd540298f0d2370f388907e2a/geminidr/interactive/interactive.py#L1082)):

```python
# if min/max value is None/Falsey, use a default.
start = min(value, min_value or 0)
end = max(value, max_value or 2 * value, 10)
```

Since this default is currently used throughout the interactive module, I've left it in for now. It will need to be changed when the interactive refactor happens.

Instead, both `build_text_slider` and `RangeField` now accept two new keyword-only arguments, `fix_start_to_min` and `fix_end_to_max` (both named to communicate the slider functionality). They are `False` by default, preserving the original behavior wherever necessary.

I chose to make them positional-only to avoid adding to positional argument function calls, since both `RangeField` and `build_text_slider` are already crowded with positional and [normal] keyword args.

## Fixes to slider stepping

The step for the slider, when using a float, was set to `0.1`. For some sliders this is greater than or equal to the total range, so now it will be `min(0.1, (end - start) / 100)` instead. This is enough for relatively smooth slider movement regardless of the start/end values.

## Other notes

This has been applied to sliders in `traceApertures` as well.

# Adds `reinit_live` fix to nested `TextHandler` class

In `PrimitiveVisualizer`, there is a `TextHandler` class (unfortunately, defined in the function) that was causing problems by trying to access the `PrimitiveVisualizer.reinit_live` without a reference to the `PrimitiveVisualizer` instance in-scope. Instead of a clever solution, like passing the instance, I'm just passing the value of `reinit_live`, since this `TextHandler` class will be refactored later.