### PR TITLE
Fix wavelength solution with no labels

### DIFF
--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -661,6 +661,8 @@ class FittingParametersUI:
                 slider_width=128,
             )
 
+        self.order_slider = builder(vis.ui_params, "order", "Order")
+
         self.sigma_upper_slider = builder(
             vis.ui_params, "sigma_upper", "Sigma (Upper)"
         )

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -661,10 +661,6 @@ class FittingParametersUI:
                 slider_width=128,
             )
 
-        # Set the order slider to have a minimum value of 1.
-        vis.ui_params.fields["order"].min = 1
-        self.order_slider = builder(vis.ui_params, "order", "Order")
-
         self.sigma_upper_slider = builder(
             vis.ui_params, "sigma_upper", "Sigma (Upper)"
         )

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -661,6 +661,8 @@ class FittingParametersUI:
                 slider_width=128,
             )
 
+        # Set the order slider to have a minimum value of 1.
+        vis.ui_params.fields["order"].min = 1
         self.order_slider = builder(vis.ui_params, "order", "Order")
 
         self.sigma_upper_slider = builder(

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -4,6 +4,7 @@ This module contains the WavelengthSolutionPanel and
 WavelengthSolutionVisualizer classes, which are used to interactively fit a
 wavelength solution to a spectrum.
 """
+from cProfile import label
 import logging
 import uuid
 
@@ -387,6 +388,15 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         # Set the initial vertical range to include some padding for labels
         label_positions = self.label_height(self.model.x)
+        
+        # Some of the following code will fail if there are no labels for any
+        # reason (e.g., no fit). In that case, we'll just set the range to the
+        # min/max of the spectrum data, which we're collecting twice here (but
+        # it's cached by the ufunc anyways).
+        if not label_positions:
+            label_positions = self.spectrum.data["spectrum"]
+
+        # 
         min_line_intensity = np.amin(label_positions)
         min_spectrum_intensity = np.amin(self.spectrum.data["spectrum"])
         max_line_intensity = np.amax(label_positions)

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -4,7 +4,6 @@ This module contains the WavelengthSolutionPanel and
 WavelengthSolutionVisualizer classes, which are used to interactively fit a
 wavelength solution to a spectrum.
 """
-from cProfile import label
 import logging
 import uuid
 


### PR DESCRIPTION
This fixes a problem where `determineWavelengthSolution` crashes without any available wavelength labels (i.e., if no lines are identified automatically). It falls back to the spectrum in this case.

It also fixes an issue with the `Order` slider being able to be set to `0`, when its minimum should be 1. This may also be the case for other sliders, since this is probably related to fixing the sliders in a previous PR (#453), as this changed how the minimum/maximum values are set (which, unfortunately, was/is spread out over a few places in the code).