### PR TITLE
Change tab name to be callable for normalizeFlat

### DIFF
--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -3486,7 +3486,7 @@ class Spect(Resample):
 
                 visualizer = fit1d.Fit1DVisualizer(reconstruct_points,
                                                    all_fp_init,
-                                                   tab_name_fmt="Array {}",
+                                                   tab_name_fmt=lambda i: f"Array {i}",
                                                    xlabel=xaxis_label, ylabel='counts',
                                                    domains=all_domains,
                                                    title="Normalize Flat",

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -1846,7 +1846,7 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
                 if isinstance(tab_name_fmt, str):
                     msg += (
                         " If you want to use a string, you should use "
-                        "a lambda function like: \n"
+                        "a lambda function like:\n"
                         "  tab_name_fmt = lambda i: f'Extension {i}'\n"
                         "or, if you want to ignore the argument, use:\n"
                         "  tab_name_fmt = lambda _: 'Extension'"

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -1834,6 +1834,26 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
                 extra_masks=extra_masks,
             )
 
+            # tab_name_fmt is expected to be a callable, which traditionally is
+            # just an anonymous function passed to the relevant visualizer as
+            # an argument.
+            if not callable(tab_name_fmt):
+                msg = (
+                    f"tab_name_fmt must be callable, but got "
+                    f"{type(tab_name_fmt)} ({tab_name_fmt})."
+                )
+
+                if isinstance(tab_name_fmt, str):
+                    msg += (
+                        " If you want to use a string, you should use "
+                        "a lambda function like: \n"
+                        "  tab_name_fmt = lambda i: f'Extension {i}'\n"
+                        "or, if you want to ignore the argument, use:\n"
+                        "  tab_name_fmt = lambda _: 'Extension'"
+                    )
+
+                raise ValueError(msg)
+
             if turbo_tabs:
                 self.turbo.add_tab(tui.component, title=str(tab_name_fmt(i)))
 


### PR DESCRIPTION
Fixes a minor bug that crashes the `normalizeFlat` interactive mode. Tab labels are expected to be callable to insert their number/some other identifier, and cannot take raw strings.