### PR TITLE
Fix axes for reconstructed points updates

### DIFF
--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -12,7 +12,6 @@ from bisect import bisect
 from functools import lru_cache
 
 from bokeh import models as bm
-from bokeh.events import Reset
 from bokeh.layouts import row, column
 from bokeh.plotting import figure
 from bokeh.models import CustomJS

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -12,6 +12,7 @@ from bisect import bisect
 from functools import lru_cache
 
 from bokeh import models as bm
+from bokeh.events import Reset
 from bokeh.layouts import row, column
 from bokeh.plotting import figure
 from bokeh.models import CustomJS
@@ -616,6 +617,9 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         p_spectrum.y_range.start = y_low
         p_spectrum.y_range.end = y_high
+        p_spectrum.y_range.reset_start = y_low
+        p_spectrum.y_range.reset_end = y_high
+
 
     def _set_refplot_axes(self):
         """Set the axes for the reference plot.
@@ -665,6 +669,8 @@ class WavelengthSolutionPanel(Fit1DPanel):
 
         p_refplot.y_range.start = y_low
         p_refplot.y_range.end = y_high
+        p_refplot.y_range.reset_start = y_low
+        p_refplot.y_range.reset_end = y_high
 
     def reset_view(self):
         super().reset_view()

--- a/geminidr/interactive/fit/wavecal.py
+++ b/geminidr/interactive/fit/wavecal.py
@@ -579,7 +579,15 @@ class WavelengthSolutionPanel(Fit1DPanel):
             self._set_refplot_axes()
 
     def _set_spectrum_plot_axes(self):
-        """Set the axes for the spectrum plot"""
+        """Set the axes for the spectrum plot.
+        
+        Notes
+        -----
+        This should only be called if the spectrum plot is shown. It can be
+        called before the plot has bounds, though.
+
+        This also overwrites the original bounds of the plot.
+        """
         p_spectrum = self.p_spectrum
         font_size = self._spectrum_label_font_size
 
@@ -625,6 +633,13 @@ class WavelengthSolutionPanel(Fit1DPanel):
         """Set the axes for the reference plot.
         
         This should only be called if the reference plot is shown.
+        
+        Notes
+        -----
+        This should only be called if the spectrum plot is shown. It can be
+        called before the plot has bounds, though.
+
+        This also overwrites the original bounds of the plot.
 
         Raises
         ------


### PR DESCRIPTION
This PR fixes a bug where axes would not be updated when points were reconstructed, leading to text and spectra overflowing the plot boundaries by default.

This moves some of the initialization previously kept in `WavelengthSolutionPanel.__init__` and moves it into methods (namely, `WavelengthSolutionPanel._set_spectrum_plot_axes()` and `<...>._set_refplot_axes()`). It also adds `<...>.reset_spectrum_axes()`, which is meant to be the public way to reset the axes.

Notably, this sets `reset_start`/`reset_end` for the spectrum and reference spectrum plots, which is what the Reset button uses when pressed. This overwrites the original settings in the plots, but those can be recovered by reconstructing the points with the original settings.