### PR TITLE
Make port assignment configurable

### DIFF
--- a/geminidr/interactive/interactive_config.py
+++ b/geminidr/interactive/interactive_config.py
@@ -33,6 +33,9 @@ class InteractiveConfig:
         self.bokeh_template_css = 'template_default.css'
         self.browser = None
 
+        # Default port number for Bokeh server
+        self.port_number = 5006
+
         try:
             cfg = globalConf['interactive']
 
@@ -63,6 +66,12 @@ class InteractiveConfig:
 
             try:
                 self.browser = cfg["browser"]
+
+            except KeyError:
+                pass
+
+            try:
+                self.port_number = int(cfg["port_number"])
 
             except KeyError:
                 pass

--- a/geminidr/interactive/server.py
+++ b/geminidr/interactive/server.py
@@ -253,11 +253,15 @@ def start_server():
     will block and this call will not return.
     """
     global _bokeh_server
+    port = interactive_conf().port_number
 
     if not _bokeh_server:
         static_app = Application(DRAGONSStaticHandler())
-        port = 5006
-        while port < 5701 and _bokeh_server is None:
+
+        # Maximum TCP/IP port number
+        max_port_number = 65535
+
+        while port < max_port_number and _bokeh_server is None:
             try:
                 # NOTE:
                 # Tornado generates a WebSocketClosedError when the user
@@ -298,7 +302,7 @@ def start_server():
                 )
             except OSError:
                 port = port + 1
-                if port >= 5701:
+                if port >= max_port_number:
                     raise
         _bokeh_server.start()
 


### PR DESCRIPTION
Adds `port_number` as a valid option in the interactive configuration option in `.dragonsrc`. E.g.,

```toml
[interactive]
port_number = 8203
```

The default is the same as it was before (`5006`).