### PR TITLE
FIX: Update AstroFaker install in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,8 @@ commands =
     which python
     which pip
     which pytest
-    pip install git+https://github.com/GeminiDRSoftware/AstroFaker#egg=AstroFaker
+    pip install wheel
+    pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker#egg=AstroFaker
     conda list
     noop: python -c "pass"  # just install deps & ensure python runs
     unit: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "not integration_test and not gmos and not gmosls and not gmosimage and not f2 and not f2ls and not f2image and not gsaoi and not niri and not nirils and not niriimage and not gnirs and not gnirsls and not gnirsimage and not gnirsxd and not wavecal and not regression and not slow and not ghost and not ghostbundle and not ghostslit and not ghostspect" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}


### PR DESCRIPTION
Adds `--no-use-pep517` to `AstroFaker` pip install in `tox.ini`, and also installs `wheel `(required with `--no-use-pep517`).