### PR TITLE
Run tests only when code/build info updates

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,17 @@ name: Run unit tests
 on:
   # pull_request:
   push:
+    paths:
+      - astrodata/**
+      - geminidr/**
+      - gemini_instruments/**
+      - gempy/**
+      - recipe_system/**
+      - tox.ini
+      - pyproject.toml
+      - setup.py
+      - setup.cfg
+      - .github/**
   workflow_dispatch:
   schedule:
     # Run every Sunday at 03:53 UTC

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,15 @@ def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
 
+previousCodeChangeCheck = null;
+
 def checkForCodeChanges() {
+  if (previousCodeChangeCheck != null) {
+    return previousCodeChangeCheck
+  } else {
+    previousCodeChangeCheck = false
+  }
+
   def build = currentBuild
   def CHANGE_SETS = build.changeSets
 
@@ -92,12 +100,13 @@ def checkForCodeChanges() {
   for (change_loc in change_locs) {
     for (file in affected_files) {
       if (file =~ change_loc && !(file =~ "/doc/")) {
-        return true
+        previousCodeChangeCheck = true;
+        return previousCodeChangeCheck
       }
     }
   }
 
-  return false;
+  return previousCodeChangeCheck;
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,8 +46,13 @@ pipeline {
 
     stages {
 
+        stage("Initial checkout") {
+          steps {
+            checkout scm
+          }
+        }
+
         stage ("Check for code changes") {
-          checkout scm
           when {
             allOf {
               changeset ".*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
 
-def codeChanged() {
+def checkForCodeChanges() {
   def CHANGE_SETS = currentBuilds.changeSets
   def affected_files = [] as Set
 
@@ -59,6 +59,8 @@ def codeChanged() {
   return false;
 }
 
+def codeChanged = checkForCodeChanges()
+
 pipeline {
 
     agent any
@@ -85,7 +87,7 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
@@ -96,7 +98,7 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
             }
             agent { label "conda" }
             environment {
@@ -123,7 +125,7 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
             }
             parallel {
 
@@ -207,7 +209,7 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
             }
             parallel {
                 stage('F2 Tests') {
@@ -401,7 +403,7 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
               expression { runtests_wavecal == 1 }
             }
 
@@ -441,7 +443,7 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              codeChanged()
+              codeChanged
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
 
-@NonCPS
 def checkForCodeChanges() {
   def build = currentBuild
   def CHANGE_SETS = build.changeSets

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,9 @@ def checkForCodeChanges() {
     // Find the last change set, in case the build is manually run.
     build = build.previousBuild
 
+    // TODO -- remove below for testing
+    echo "Trying with build: ${build.id}"
+
     if (build == null) {
       echo "Could not find previous build with changes."
       break

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,18 +22,6 @@ def runtests_gnirs   = 1
 def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
-boolean changed_code = any({
-  changeset "astrodata/**"
-  changeset "geminidr/**"
-  changeset "gemini_instruments/**"
-  changeset "gempy/**"
-  changeset "recipe_system/**"
-  changeset "Jenkinsfile"
-  changeset "tox.ini"
-  changeset "pyproject.toml"
-  changeset "setup.py"
-  changeset "setup.cfg"
-})
 
 pipeline {
 
@@ -61,7 +49,18 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
@@ -72,7 +71,18 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
             }
             agent { label "conda" }
             environment {
@@ -99,7 +109,18 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
             }
             parallel {
 
@@ -183,7 +204,18 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
             }
             parallel {
                 stage('F2 Tests') {
@@ -377,7 +409,18 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
               expression { runtests_wavecal == 1 }
             }
 
@@ -417,7 +460,18 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              changed_code
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,18 @@ def runtests_gnirs   = 1
 def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
+boolean changed_code = any({
+  changeset "astrodata/**"
+  changeset "geminidr/**"
+  changeset "gemini_instruments/**"
+  changeset "gempy/**"
+  changeset "recipe_system/**"
+  changeset "Jenkinsfile"
+  changeset "tox.ini"
+  changeset "pyproject.toml"
+  changeset "setup.py"
+  changeset "setup.cfg"
+})
 
 pipeline {
 
@@ -49,18 +61,7 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,21 @@ pipeline {
     stages {
 
         stage ("Prepare"){
+            when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
                 // sendNotifications 'STARTED'
@@ -54,6 +69,21 @@ pipeline {
         }
 
         stage('Pre-install') {
+            when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
             agent { label "conda" }
             environment {
                 TMPDIR = "${env.WORKSPACE}/.tmp/conda/"
@@ -77,6 +107,21 @@ pipeline {
         }
 
         stage('Quicker tests') {
+            when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
             parallel {
 
                 stage('Unit tests') {
@@ -157,6 +202,21 @@ pipeline {
         }
 
         stage('Instrument tests') {
+            when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
             parallel {
                 stage('F2 Tests') {
                     when {
@@ -385,6 +445,21 @@ pipeline {
         }  // end stage
 
         stage('Slower tests') {
+            when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
             parallel {
                 stage('GMOS LS Tests') {
                     when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
 
+@NonCPS
 def checkForCodeChanges() {
   def CHANGE_SETS = currentBuild.changeSets
   def affected_files = [] as Set

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,18 +72,7 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
             }
             agent { label "conda" }
             environment {
@@ -110,18 +99,7 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
             }
             parallel {
 
@@ -205,18 +183,7 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
             }
             parallel {
                 stage('F2 Tests') {
@@ -410,18 +377,7 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
               expression { runtests_wavecal == 1 }
             }
 
@@ -461,18 +417,7 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              changed_code
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,11 +25,26 @@ def runtests_gmos    = 1
 
 @NonCPS
 def checkForCodeChanges() {
-  def CHANGE_SETS = currentBuild.changeSets
+  def build = currentBuild
+  def CHANGE_SETS = build.changeSets
+
+  while (!CHANGE_SETS) {
+    // Find the last change set, in case the build is manually run.
+    build = build.previousBuild
+
+    if (build == null) {
+      echo "Could not find previous build with changes."
+      break
+    }
+
+    CHANGE_SETS = build.changeSets
+  }
+
   def affected_files = [] as Set
 
   for (change_set in CHANGE_SETS) {
     for (file in change_set.getAffectedFiles()) {
+      echo "Found file: ${file}"
       affected_files.add(file)
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -408,6 +408,21 @@ pipeline {
 
         stage('WaveCal Tests') {
             when {
+              beforeAgent true
+              anyOf {
+                changeset "astrodata/**"
+                changeset "geminidr/**"
+                changeset "gemini_instruments/**"
+                changeset "gempy/**"
+                changeset "recipe_system/**"
+                changeset "Jenkinsfile"
+                changeset "tox.ini"
+                changeset "pyproject.toml"
+                changeset "setup.py"
+                changeset "setup.cfg"
+              }
+            }
+            when {
                 expression { runtests_wavecal == 1 }
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ def checkForCodeChanges() {
   def affected_files = [] as Set
 
   for (change_set in CHANGE_SETS) {
-    for (file in change_set) {
+    for (file in change_set.getAffectedFiles()) {
       affected_files.add(file)
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,42 @@ def runtests_wavecal = 1
 def runtests_ghost   = 1
 def runtests_gmos    = 1
 
+def codeChanged() {
+  def CHANGE_SETS = currentBuilds.changeSets
+  def affected_files = [] as Set
+
+  for (change_set in CHANGE_SETS) {
+    for (file in change_set) {
+      affected_files.add(file)
+    }
+  }
+
+  println "Current changeset: ${affected_files}"
+
+  def change_locs = [
+    "astrodata",
+    "geminidr",
+    "gemini_instruments",
+    "gempy",
+    "recipe_system",
+    "Jenkinsfile",
+    "tox.ini",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+  ]
+
+  for (change_loc in change_locs) {
+    for (file in affected_files) {
+      if (file =~ change_loc && !(file =~ "/doc/")) {
+        return true
+      }
+    }
+  }
+
+  return false;
+}
+
 pipeline {
 
     agent any
@@ -49,18 +85,7 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              codeChanged()
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
@@ -71,18 +96,7 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              codeChanged()
             }
             agent { label "conda" }
             environment {
@@ -109,17 +123,7 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
+              codeChanged()
               }
             }
             parallel {
@@ -204,18 +208,7 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              codeChanged()
             }
             parallel {
                 stage('F2 Tests') {
@@ -409,18 +402,7 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              codeChanged()
               expression { runtests_wavecal == 1 }
             }
 
@@ -460,18 +442,7 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              anyOf {
-                changeset "astrodata/**"
-                changeset "geminidr/**"
-                changeset "gemini_instruments/**"
-                changeset "gempy/**"
-                changeset "recipe_system/**"
-                changeset "Jenkinsfile"
-                changeset "tox.ini"
-                changeset "pyproject.toml"
-                changeset "setup.py"
-                changeset "setup.cfg"
-              }
+              codeChanged()
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,6 @@ pipeline {
         }
 
         stage ("Prepare"){
-            when {
-              expression { checkForCodeChanges() }
-            }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
                 // sendNotifications 'STARTED'
@@ -77,9 +74,6 @@ pipeline {
         }
 
         stage('Pre-install') {
-            when {
-              expression { checkForCodeChanges() }
-            }
             agent { label "conda" }
             environment {
                 TMPDIR = "${env.WORKSPACE}/.tmp/conda/"
@@ -103,9 +97,6 @@ pipeline {
         }
 
         stage('Quicker tests') {
-            when {
-              expression { checkForCodeChanges() }
-            }
             parallel {
 
                 stage('Unit tests') {
@@ -186,9 +177,6 @@ pipeline {
         }
 
         stage('Instrument tests') {
-            when {
-              expression { checkForCodeChanges() }
-            }
             parallel {
                 stage('F2 Tests') {
                     when {
@@ -380,7 +368,6 @@ pipeline {
 
         stage('WaveCal Tests') {
             when {
-              expression { checkForCodeChanges() }
               expression { runtests_wavecal == 1 }
             }
 
@@ -418,9 +405,6 @@ pipeline {
         }  // end stage
 
         stage('Slower tests') {
-            when {
-              expression { checkForCodeChanges() }
-            }
             parallel {
                 stage('GMOS LS Tests') {
                     when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,8 @@ def checkForCodeChanges() {
     previousCodeChangeCheck = false
   }
 
+  checkout scm
+
   def build = currentBuild
   def CHANGE_SETS = build.changeSets
 
@@ -106,7 +108,7 @@ def checkForCodeChanges() {
     }
   }
 
-  return previousCodeChangeCheck;
+  return previousCodeChangeCheck
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,6 @@ pipeline {
 
         stage ("Prepare"){
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
             }
             steps{
@@ -145,7 +144,6 @@ pipeline {
 
         stage('Pre-install') {
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
             }
             agent { label "conda" }
@@ -172,7 +170,6 @@ pipeline {
 
         stage('Quicker tests') {
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
             }
             parallel {
@@ -256,7 +253,6 @@ pipeline {
 
         stage('Instrument tests') {
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
             }
             parallel {
@@ -450,7 +446,6 @@ pipeline {
 
         stage('WaveCal Tests') {
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
               expression { runtests_wavecal == 1 }
             }
@@ -490,7 +485,6 @@ pipeline {
 
         stage('Slower tests') {
             when {
-              beforeAgent true
               expression { checkForCodeChanges() }
             }
             parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,11 +40,25 @@ def checkForCodeChanges() {
   }
 
   // If past builds (limited by kept number of builds per branch) didn't have
-  // anything, last resort: check the git log for the last 24 hours.
+  // anything, penultimate resort: check the git log for the last 24 hours.
   if (!CHANGE_SETS) {
+    echo "Checking the git log for changes (last 24 hours)"
     def git_log_files = sh(
       returnStdout: true,
       script: "git log --since=1.day --oneline --name-only --pretty=\"format:\""
+    )
+
+    List files = git_log_files.split('\n').findAll { it }
+    CHANGE_SETS = [files as Set] as Set
+  }
+
+  // Final check: just get the last 5 commits and check against those (assuming
+  // no commits made in last 24 hours, still doing a manual build).
+  if (!CHANGE_SETS) {
+    echo "Checking the git log for changes (last 5 commits)"
+    def git_log_files = sh(
+      returnStdout: true,
+      script: "git log -5 --oneline --name-only --pretty=\"format:\""
     )
 
     List files = git_log_files.split('\n').findAll { it }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,11 @@ def checkForCodeChanges() {
       break
     }
 
-    CHANGE_SETS = build.changeSets
+    CHANGE_SETS = [] as Set
+
+    for (change_set in build.changeSets) {
+      CHANGE_SETS.add(change_set.getAffectedFiles())
+    }
   }
 
   // If past builds (limited by kept number of builds per branch) didn't have
@@ -78,7 +82,7 @@ def checkForCodeChanges() {
   def affected_files = [] as Set
 
   for (change_set in CHANGE_SETS) {
-    for (file in change_set.getAffectedFiles()) {
+    for (file in change_set) {
       echo "Found file: ${file}"
       affected_files.add(file)
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def checkForCodeChanges() {
     }
   }
 
-  println "Current changeset: ${affected_files}"
+  echo "Current changeset: ${affected_files}"
 
   def change_locs = [
     "astrodata",
@@ -58,8 +58,6 @@ def checkForCodeChanges() {
 
   return false;
 }
-
-def codeChanged = checkForCodeChanges()
 
 pipeline {
 
@@ -87,7 +85,7 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
@@ -98,7 +96,7 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
             }
             agent { label "conda" }
             environment {
@@ -125,7 +123,7 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
             }
             parallel {
 
@@ -209,7 +207,7 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
             }
             parallel {
                 stage('F2 Tests') {
@@ -403,7 +401,7 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
               expression { runtests_wavecal == 1 }
             }
 
@@ -443,7 +441,7 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              expression { codeChanged }
+              expression { checkForCodeChanges() }
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
     stages {
 
         stage ("Check for code changes") {
+          checkout scm
           when {
             allOf {
               changeset ".*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         stage ("Prepare"){
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
             }
             steps{
                 echo "Step would notify STARTED when dragons_ci is available"
@@ -98,7 +98,7 @@ pipeline {
         stage('Pre-install') {
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
             }
             agent { label "conda" }
             environment {
@@ -125,7 +125,7 @@ pipeline {
         stage('Quicker tests') {
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
             }
             parallel {
 
@@ -209,7 +209,7 @@ pipeline {
         stage('Instrument tests') {
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
             }
             parallel {
                 stage('F2 Tests') {
@@ -403,7 +403,7 @@ pipeline {
         stage('WaveCal Tests') {
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
               expression { runtests_wavecal == 1 }
             }
 
@@ -443,7 +443,7 @@ pipeline {
         stage('Slower tests') {
             when {
               beforeAgent true
-              codeChanged
+              expression { codeChanged }
             }
             parallel {
                 stage('GMOS LS Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def runtests_ghost   = 1
 def runtests_gmos    = 1
 
 def checkForCodeChanges() {
-  def CHANGE_SETS = currentBuilds.changeSets
+  def CHANGE_SETS = currentBuild.changeSets
   def affected_files = [] as Set
 
   for (change_set in CHANGE_SETS) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,6 @@ pipeline {
             when {
               beforeAgent true
               codeChanged()
-              }
             }
             parallel {
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -421,9 +421,7 @@ pipeline {
                 changeset "setup.py"
                 changeset "setup.cfg"
               }
-            }
-            when {
-                expression { runtests_wavecal == 1 }
+              expression { runtests_wavecal == 1 }
             }
 
             agent { label "master" }

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -40,6 +40,10 @@ _arit_doc = """
 """
 
 
+# TODO: REMOVE --- FOR TESTING
+pass
+
+
 class AstroData:
     """
     Base class for the AstroData software package. It provides an interface

--- a/astrodata/core.py
+++ b/astrodata/core.py
@@ -25,6 +25,9 @@ from .utils import (assign_only_single_slice, astro_data_descriptor,
 
 NO_DEFAULT = object()
 
+# TODO: REMOVE -- for jenkins testing
+pass
+
 
 _arit_doc = """
     Performs {name} by evaluating ``self {op} operand``.

--- a/astrodata/doc/progmanual/adclass.rst
+++ b/astrodata/doc/progmanual/adclass.rst
@@ -6,6 +6,8 @@
 AstroData and Derivatives
 *************************
 
+.. todo:: remove this, for jenkins tests
+
 The |AstroData| class is the main interface to the package. When opening files
 or creating new objects, a derivative of this class is returned, as the
 |AstroData| class is not intended to be used directly. It provides the logic to

--- a/doc/DRAGONS/development/testing.rst
+++ b/doc/DRAGONS/development/testing.rst
@@ -1,0 +1,16 @@
+
+Testing DRAGONS
+===============
+
+Testing Pipeline
+----------------
+
+The DRAGONS testing pipeline consists of:
+
++ Initial testing run using Github Actions
++ A more comprehensive test suite run using a managed Jenkins server
+
+Ideally, changes to source code should be associated with tests and we aim for
+our test coverage to increase or stay the same as source code is modified and
+added. CodeCov is used to assess test coverage, and will post coverage updates
+to pull requests.


### PR DESCRIPTION
# Summary

This modifies the `Jenkinfile` and GitHub unit tests workflow to only run the tests when certain directories/files are changed.

Specifically, it looks for changes to:

+ The main code modules shipped with DRAGONS (`astrodata`, `geminidr`, `gemini_instruments`, `gempy`, and `recipe_system`)
+ Build files/data (e.g., `pyproject.toml`, `setup.py`)
+ Test configurations (`Jenkinsfile`, `.github/`, `tox.ini`)