### PR TITLE
merge Enh/fixlogging - restore API compatibility between gempy logger and python logger, tidy up

### DIFF
--- a/geminidr/core/tests/test_spect.py
+++ b/geminidr/core/tests/test_spect.py
@@ -609,7 +609,7 @@ def test_flux_conservation_consistency(astrofaker, caplog, unit,
                     flux_calibrated=flux_calibrated, log=p.log)
     correct, warn = RESULTS[unit, flux_calibrated, user_conserve]
     assert conserve == correct
-    warning_given = any("WARNING" in record.message for record in caplog.records)
+    warning_given = any(record.levelname == 'WARNING' for record in caplog.records)
     assert warn == warning_given
 
 

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -1,6 +1,7 @@
 """
 Tests for primitives_stack.
 """
+import logging
 
 import numpy as np
 import pytest
@@ -132,6 +133,7 @@ def test_stacking_without_gain_or_readnoise(f2_adinputs):
 
 
 def test_stacking_gain_read_noise_propagation(f2_adinputs, caplog):
+    caplog.set_level(logging.WARNING)
     f2_adinputs[0].phu["LNRS"] = 1
     f2_adinputs[1].phu["LNRS"] = 8
     p = F2Image(f2_adinputs)

--- a/gempy/utils/logutils.py
+++ b/gempy/utils/logutils.py
@@ -164,7 +164,6 @@ class DragonsConsoleFormatter(logging.Formatter):
         return ' ' * (self._indent_level * self._indent_width)
 
     def _init_formatters(self):
-        print("Init formatters")
         self._short_fmt_str = self._indent_str() + '%(message)s'
         self._long_fmt_str = self._indent_str() + '%(levelname)s - %(message)s'
         self._short_formatter = logging.Formatter(self._short_fmt_str)
@@ -176,12 +175,9 @@ class DragonsConsoleFormatter(logging.Formatter):
 
     def format(self, record):
         # Levels for which to emit short form
-        print(f"{record.levelname=} {self.short_levels=}")
         if record.levelname in self.short_levels:
-            print("short")
             return self._short_formatter.format(record)
         else:
-            print("long")
             return self._long_formatter.format(record)
 
 
@@ -323,7 +319,7 @@ def change_level(new_level=None):
 class DuplicateWarningFilter(logging.Filter):
     """
     This class contains a filter for log messages to suppress repeated instances
-    of the same message. When a different message comes along, it prints a
+    of the same message. When a different message comes along, it logs a
     message summarizing how many duplicate messages were suppressed.
 
     Parameters

--- a/gempy/utils/logutils.py
+++ b/gempy/utils/logutils.py
@@ -1,11 +1,44 @@
+"""
+gempy.utils.logutils provides functions to support logging in DRAGONS. There are
+two groups of functions:
+
+Logging setup:
+
+- customize_logger()
+DRAGONS logging uses some extra non-standard logging levels. The
+customize_logger() function provided here will add the extra levels to the
+logging namespace, and will also add methods to a logger to log messages
+with those levels - eg log.fullinfo() is the equivalent of log.info() but for
+the custom FULLINFO level. It will also add a filter to avoid identical repeat
+warning messages. It will *not* add or remove handlers to or from the logger.
+
+3rd party applications calling dragons code that configure their own log
+handlers should call customize_logger() to add the extra levels to the logger.
+
+- config()
+This is the traditional logging configuration method for DRAGONS. It will call
+customize_logger() to set up additional log levels. It will also add file and
+stream (console) handlers to the logger. The console handler gets a custom
+formatter that includes the level name in the output only for non-info-like
+levels.
+
+Some other utility methods are provided to support logging in DRAGONS:
+
+- get_logger() gets the root logger, and ensures that customize_logger has been
+run on it.
+
+- update_indent() updates the format strings, and the console log custom
+formatter, to facilitate indenting log messages to reflect call stack depth in
+recipes and primitives.
+"""
+
 #
 #                                                                  gemini_python
 #
 #                                                                    gempy.utils
 #                                                                    logutils.py
 # ------------------------------------------------------------------------------
-# $Id$
-# ------------------------------------------------------------------------------
+
 import logging
 from logging import handlers
 from collections.abc import Iterable

--- a/gempy/utils/tests/test_logutils.py
+++ b/gempy/utils/tests/test_logutils.py
@@ -1,0 +1,60 @@
+from _pytest.logging import LogCaptureHandler
+
+import logging
+from gempy.utils import logutils
+
+log = logutils.get_logger()
+
+
+def test_sanity(caplog):
+    caplog.set_level(logging.NOTSET)
+    log.info("Hello, world!")
+    assert 'Hello, world!' in caplog.text
+
+def test_fullinfo(caplog):
+    caplog.set_level(logging.NOTSET)
+    log.fullinfo("Fullinfo is an extra log level")
+    assert "Fullinfo is an extra log level" in caplog.text
+
+def test_nofullinfo(caplog):
+    # At INFO level (20), FULLINFO (15) should not show up
+    caplog.set_level(logging.INFO)
+    log.fullinfo("Fullinfo is an extra log level")
+    assert "Fullinfo is an extra log level" not in caplog.text
+
+def test_conditional_levelname(caplog):
+    caplog.set_level(logging.INFO)
+    logutils.change_level(logging.INFO)
+    for handler in log.handlers:
+        if isinstance(handler, LogCaptureHandler):
+            handler.formatter = logutils.DragonsConsoleFormatter()
+    log.info("Info message")
+    assert "Info message" in caplog.text
+    assert "INFO" not in caplog.text
+
+def test_conditional_levelname2(caplog):
+    caplog.set_level(logging.NOTSET)
+    for handler in log.handlers:
+        if isinstance(handler, LogCaptureHandler):
+            handler.formatter = logutils.DragonsConsoleFormatter()
+    log.warning("Warn message")
+    assert "WARNING - Warn message" in caplog.text
+
+def test_indent(caplog):
+    caplog.set_level(logging.NOTSET)
+    for handler in log.handlers:
+        if isinstance(handler, LogCaptureHandler):
+            handler.formatter = logutils.DragonsConsoleFormatter()
+    log.info("zero indent")
+    assert caplog.text == "zero indent\n"
+
+    # indents are three spaces
+    caplog.clear()
+    logutils.update_indent(1)
+    log.info("one indent")
+    assert caplog.text == "   one indent\n"
+
+    caplog.clear()
+    logutils.update_indent(2)
+    log.info("two indent")
+    assert caplog.text == "      two indent\n"

--- a/recipe_system/mappers/primitiveMapper.py
+++ b/recipe_system/mappers/primitiveMapper.py
@@ -14,7 +14,6 @@ from .baseMapper import Mapper
 
 from ..utils.mapper_utils import dotpath
 from ..utils.errors import PrimitivesNotFound
-from ..utils.rs_utilities import log_traceback
 # ------------------------------------------------------------------------------
 log = logutils.get_logger(__name__)
 # ------------------------------------------------------------------------------
@@ -77,7 +76,7 @@ class PrimitiveMapper(Mapper):
         try:
             loaded_pkg = import_module(self.dotpackage)
         except ModuleNotFoundError:
-            log_traceback(log)
+            log.error("Uncaught exception", exc_info=True)
             yield None
             return
         for pkgpath, pkg in self._generate_primitive_modules(loaded_pkg):

--- a/recipe_system/reduction/coreReduce.py
+++ b/recipe_system/reduction/coreReduce.py
@@ -36,7 +36,6 @@ from recipe_system.utils.errors import PrimitivesNotFound
 from recipe_system.utils.reduce_utils import buildParser
 from recipe_system.utils.reduce_utils import normalize_ucals
 from recipe_system.utils.reduce_utils import set_btypes
-from recipe_system.utils.rs_utilities import log_traceback
 
 from recipe_system.mappers.recipeMapper import RecipeMapper
 from recipe_system.mappers.primitiveMapper import PrimitiveMapper
@@ -590,16 +589,15 @@ def reduce_data(files, mode='sq', drpkg='geminidr', recipename=None, uparms={}, 
         try:
             primitive_as_recipe()
         except Exception as err:
-            log_traceback(log)
-            log.error(str(err))
+            log.error("Reduce received an unhandled exception.", exc_info=True)
             raise
     else:
         _logheader(recipe, recipename)
         try:
             recipe(p)
         except Exception:
-            log.error("Reduce received an unhandled exception. Aborting ...")
-            log_traceback(log)
+            log.error("Reduce received an unhandled exception. Aborting ...",
+                      exc_info=True)
             log.stdinfo("Writing final outputs ...")
             try:
                 for ad in p.streams['main']:

--- a/recipe_system/scripts/reduce.py
+++ b/recipe_system/scripts/reduce.py
@@ -7,6 +7,7 @@
 # ---------------------------- Package Import ----------------------------------
 import sys
 import signal
+from sys import exc_info
 
 from gempy.utils import logutils
 
@@ -70,15 +71,9 @@ def main(args):
     """
     estat = 0
     log = logutils.get_logger(__name__)
-    try:
-        assert log.root.handlers
-        log.root.handlers = []
-        logutils.config(mode=args.logmode, file_name=args.logfile)
-        log = logutils.get_logger(__name__)
-        log.info("Logging configured for application: reduce")
-        log.info(" ")
-    except AssertionError:
-        pass
+    logutils.config(mode=args.logmode, file_name=args.logfile)
+    log.info("Logging configured for application: reduce")
+    log.info(" ")
 
     log.stdinfo("\n\t\t\t--- reduce v{} ---".format(rs_version))
     log.stdinfo("\nRunning on Python {}".format(sys.version.split()[0]))
@@ -92,9 +87,7 @@ def main(args):
         log.error(str(err))
         estat = signal.SIGABRT
     except Exception as err:
-        log.error("reduce caught an unhandled exception.\n")
-        log.error(err)
-        log_traceback(log)
+        log.error("reduce caught an unhandled exception.\n", exc_info=True)
         log.error("\nReduce instance aborted.")
         estat = signal.SIGABRT
 

--- a/recipe_system/scripts/reduce.py
+++ b/recipe_system/scripts/reduce.py
@@ -22,8 +22,6 @@ from recipe_system.utils.reduce_utils import normalize_upload
 from recipe_system.utils.reduce_utils import show_parser_options
 
 from recipe_system.config import globalConf
-
-from recipe_system.utils.rs_utilities import log_traceback
 # ------------------------------------------------------------------------------
 def main(args):
     """

--- a/recipe_system/utils/rs_utilities.py
+++ b/recipe_system/utils/rs_utilities.py
@@ -2,19 +2,12 @@
 Set of functions in support of the recipe_system.
 
 """
-import sys
 import errno
 import itertools
-import traceback
 
 from os import makedirs
 from os.path import join
 
-def log_traceback(log):
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    tblist = traceback.format_exception(exc_type, exc_value, exc_traceback)
-    [log.error(line.rstrip()) for line in tblist]
-    return
 
 def makedrpkg(pkgname, instruments, modes=None):
     """


### PR DESCRIPTION
* Restores API compatibility of the `gempy.utils.logutils` logger with the python native logger, which had been broken by introduction of custom `log.methods()` that assumed the only argument passed would be a string, which is not the general case. These had been introduced to provide functionality to only put the log level name in the console log for WARNINGs and above and DEBUGs (ie not for the info type messages). This is now implemented with a custom formatter class in the console log handler.
* Adds tests for gempy logutils
* Tidies up and documents the logutils.py module somewhat
* Removes the log_traceback code from rs_utilities and replaces calls to it to use python native logger `excinfo=True` functionality instead.

* This PR currently does NOT change the custom log levels that are added to the logger.