### PR TITLE
Fix a bug returning telluric models to the primitive. Plus force a parameter change in resampleToCommonFrame

### DIFF
--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -8,8 +8,12 @@ from astropy.io import registry
 from astrodata import AstroData
 from geminidr.core import parameters_generic
 from gempy.library import config, astrotools as at
+from gempy.utils import logutils
 
 from . import parameters_preprocess
+
+
+log = logutils.get_logger(__name__)
 
 
 def list_of_ints_check(value):
@@ -592,7 +596,9 @@ class resampleToCommonFrameConfig(config.Config):
         # only valid over the extent of its extension. Extrapolating it could
         # lead to large errors. TODO: gwcs's numerical inverse?
         if self.output_wave_scale == "reference" and not self.trim_spectral:
-            raise ValueError("Must set trim_spectral=True if output_wave_scale='reference'")
+            log.warning("output_wave_scale='reference' is incompatible with "
+                        "trim_spectral=True. Setting trim_spectral=False")
+            self.trim_spectral = False
 
 
 class separateSkyConfig(parameters_preprocess.separateSkyConfig):

--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -597,8 +597,8 @@ class resampleToCommonFrameConfig(config.Config):
         # lead to large errors. TODO: gwcs's numerical inverse?
         if self.output_wave_scale == "reference" and not self.trim_spectral:
             log.warning("output_wave_scale='reference' is incompatible with "
-                        "trim_spectral=True. Setting trim_spectral=False")
-            self.trim_spectral = False
+                        "trim_spectral=False. Setting trim_spectral=True")
+            self.trim_spectral = True
 
 
 class separateSkyConfig(parameters_preprocess.separateSkyConfig):

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -4003,14 +4003,11 @@ class Spect(Resample):
             # Use the existing wavelength solution(s) of the reference AD
             npix = np.empty_like(wave_min, dtype=int)
             w1, w2 = wave_min, wave_max
-            print(w1)
-            print(w2)
             new_wave_models = []
             for iext, (extinfo, this_w1, this_w2) in enumerate(
                     zip(info[0], wave_min, wave_max)):
                 wave_model_ref = extinfo['wave_model'].copy()
                 limits = wave_model_ref.inverse([this_w1, this_w2])
-                print(limits)
                 # Due to imperfections in the Chebyshev inverse, we check
                 # whether the wavelength limits are the same as the
                 # reference spectrum.
@@ -4019,7 +4016,6 @@ class Spect(Resample):
                 if extinfo['w2'] == this_w2:
                     limits[1] = round(limits[1])
                 pixel_shift = int(np.ceil(limits.min()))
-                print(limits, pixel_shift, wave_model_ref(limits))
                 if pixel_shift:
                     new_wave_model = models.Shift(pixel_shift) | wave_model_ref
                 else:
@@ -4036,10 +4032,7 @@ class Spect(Resample):
                 actual_limits = new_wave_model([0, this_npix - 1])
                 w1[iext] = actual_limits.min()
                 w2[iext] = actual_limits.max()
-                print(new_wave_model([0,1,2]))
                 yy = new_wave_model([this_npix-3,this_npix-2,this_npix-1])
-                print(this_npix, yy)
-                print(new_wave_model.inverse(yy))
 
             # Calculation for all extensions
             dw = (w2 - w1) / (npix - 1)

--- a/geminidr/gmos/tests/spect/test_resample.py
+++ b/geminidr/gmos/tests/spect/test_resample.py
@@ -79,15 +79,23 @@ def test_resample_linearize_trim_and_stack(input_ad_list, caplog):
 @pytest.mark.preprocessed_data
 def test_resample_only(input_ad_list, caplog):
     p = GMOSLongslit(input_ad_list)
-    # This will raise an error as explained in parameters_spect.py
-    with pytest.raises(ValueError):
-        p.resampleToCommonFrame(output_wave_scale="reference")
-    # _check_params(caplog.records, 'w1=508.489 w2=1088.232 dw=0.151 npix=3840')
-    #
-    # caplog.clear()
-    # adout = p.resampleToCommonFrame(dw=0.15)
-    # assert 'ALIGN' in adout[0].phu
-    # _check_params(caplog.records, 'w1=508.489 w2=1088.239 dw=0.150 npix=3866')
+    p.resampleToCommonFrame(output_wave_scale="reference")
+    _check_params(caplog.records, 'w1=614.870 w2=978.802 dw=0.151 npix=2407')
+
+    caplog.clear()
+    adout = p.resampleToCommonFrame(dw=0.15)
+    assert 'ALIGN' in adout[0].phu
+    _check_params(caplog.records, 'w1=614.870 w2=978.920 dw=0.150 npix=2428')
+
+    # # This will raise an error as explained in parameters_spect.py
+    # with pytest.raises(ValueError):
+    #     p.resampleToCommonFrame(output_wave_scale="reference")
+    # # _check_params(caplog.records, 'w1=508.489 w2=1088.232 dw=0.151 npix=3840')
+    # #
+    # # caplog.clear()
+    # # adout = p.resampleToCommonFrame(dw=0.15)
+    # # assert 'ALIGN' in adout[0].phu
+    # # _check_params(caplog.records, 'w1=508.489 w2=1088.239 dw=0.150 npix=3866')
 
 
 @pytest.mark.gmosls

--- a/geminidr/gnirs/tests/longslit/test_resample_2d.py
+++ b/geminidr/gnirs/tests/longslit/test_resample_2d.py
@@ -45,23 +45,6 @@ def test_resample_to_common_frame_with_defaults(input_ad_list, path_to_refs,
 
 @pytest.mark.gnirsls
 @pytest.mark.preprocessed_data
-def test_resample_to_common_frame_nonlinear(input_ad_list, path_to_refs,
-                                            caplog):
-    p = GNIRSLongslit(input_ad_list)
-    # This will raise an error as explained in parameters_spect.py
-    with pytest.raises(ValueError):
-        p.resampleToCommonFrame(trim_spatial=True, trim_spectral=False,
-                                output_wave_scale="reference")
-    #ad_out = p.stackFrames()[0]
-    #_check_params(caplog.records, 'w1=1525.312 w2=1806.015 dw=0.135 npix=2082')
-    #assert 'ALIGN' in ad_out[0].phu
-    #ref = astrodata.open(os.path.join(path_to_refs,
-    #                                  'N20240329S0022_stack_nonlinear.fits'))
-
-    #np.testing.assert_allclose(ad_out[0].data, ref[0].data)
-
-@pytest.mark.gnirsls
-@pytest.mark.preprocessed_data
 def test_resample_to_common_frame_trim_spectral(input_ad_list, path_to_refs,
                                                 caplog):
     p = GNIRSLongslit(input_ad_list)

--- a/gempy/library/telluric_models.py
+++ b/gempy/library/telluric_models.py
@@ -200,9 +200,9 @@ class SingleTelluricModel(Fittable1DModel):
         self.pca_params = slice(None, len(names))
         self.cont_params = slice(len(names), None)
         if self.continuum_function == self.spline3:
-            names.extend([f'spl{i:02d}' for i in range(self.order+3)])
+            names.extend([f'spl{i:02d}' for i in range(self.order + 3)])
         else:
-            names.extend([f'cheb{i:02d}' for i in range(self.order)])
+            names.extend([f'cheb{i:02d}' for i in range(self.order + 1)])
         return tuple(names)
 
     @property
@@ -318,7 +318,6 @@ class MultipleTelluricModels(Fittable1DModel):
         for tspek, func, ord in zip(spectra, self.functions, self.orders):
             self.models.append(SingleTelluricModel(
                 tspek=tspek, function=func, order=ord))
-
         self.nparams = []
         self._param_names = self._generate_coeff_names()
         for param_name in self._param_names:
@@ -344,8 +343,8 @@ class MultipleTelluricModels(Fittable1DModel):
                 names.extend([f'm{n}spl{i:02d}' for i in range(ord + 3)])
                 self.nparams.append(ord + 3)
             else:
-                names.extend([f'm{n}cheb{i}' for i in range(ord)])
-                self.nparams.append(ord)
+                names.extend([f'm{n}cheb{i}' for i in range(ord + 1)])
+                self.nparams.append(ord + 1)
         return tuple(names)
 
     def concatenate(self, property='data'):
@@ -404,7 +403,7 @@ class MultipleTelluricModels(Fittable1DModel):
         self.update_individual_models()
         npca_parameters = self.npca_components - 1  # because of the mean
         individual_models = []
-        start_param = npca_parameters
+        start_param = len(self.models[0].pca.param_names)  # includes LSF params
         for m, nparams in zip(self.models, self.nparams):
             these_params = self.parameters[start_param:start_param+nparams]
             this_model = m.continuum_function(these_params)


### PR DESCRIPTION
Two things.

1. The `TelluricCalibrator` object was returning the wrong values as coefficients of the continuum model fit due to an indexing mistake, which has been fixed. Also, the Chebyshev model was actually using an order 1 less than requested because of python's non-inclusive maximum.
2. In `Spect.resampleToCommonFrame()` the combination `output_wave_scale="reference"` and `trim_spectral=False` is not allowed because it may require extrapolating the wavelength solution and round-tripping could become inaccurate. This combination of parameters previously raised a `ValueError` but not a warning is logged and `trim_spectral=True` is enforced.