### PR TITLE
A system/user-wide cache for calibration file downloads

### DIFF
--- a/recipe_system/cal_service/calrequestlib.py
+++ b/recipe_system/cal_service/calrequestlib.py
@@ -7,27 +7,18 @@ import hashlib
 
 from gempy.utils import logutils
 
-# GetterError is needed by a module that imports this one
-from .file_getter import get_file_iterator, GetterError
 # ------------------------------------------------------------------------------
 log = logutils.get_logger(__name__)
 # ------------------------------------------------------------------------------
 # Currently delivers transport_request.calibration_search fn.
 #calibration_search = cal_search_factory()
 # ------------------------------------------------------------------------------
-def get_request(url, filename):
-    iterator = get_file_iterator(url)
-    with open(filename, 'wb') as fd:
-        for chunk in iterator:
-            fd.write(chunk)
-    return filename
 
 
 def generate_md5_digest(filename):
-    md5 = hashlib.md5()
-    fdata = open(filename, 'rb').read()
-    md5.update(fdata)
-    return md5.hexdigest()
+    with open(filename, 'rb') as f:
+        digest = hashlib.file_digest(f, "md5")
+    return digest.hexdigest()
 
 
 class CalibrationRequest:

--- a/recipe_system/cal_service/file_getter.py
+++ b/recipe_system/cal_service/file_getter.py
@@ -1,45 +1,112 @@
+import shutil
+import os.path
 import requests
 from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 from requests.exceptions import ConnectionError
 
-from gempy.utils import logutils
+from . import get_calconf
+from gempy.utils.logutils import get_logger
+from .calrequestlib import generate_md5_digest
+
+# get_file_itterator is the only function in this module called externally
+# (from calrequestlib.py)
+
+def get_request(url, filename, calmd5):
+    """
+    This function was moved from calrequestlib.py as it belongs more naturally
+    in this module as it is the only thing that calls methods in this module.
+    Those methods where replaced with the CachedFileGetter class.
+    :param url: URL to fetch data from
+    :param filename: Filename to put data into
+    :param calmd5: md5 hexdigest of cal we are requesting
+    :return: None
+    """
+    cfg = CachedFileGetter()
+    cfg.get_request(url, filename, calmd5)
+
+class CachedFileGetter(object):
+    """
+    This class implements a file getter with an optional system- (or user-)
+    wide cache. To enable the cache, set system_calcache_dir to point at the
+    cache directory in the [calibs] section of your dragonsrc. If this is unset
+    or None, no caching is attempted. This cache is only really useful on
+    machines which run lots of instances of reduce in separate working
+    directories, notably for archive processing.
+
+    This class is not a singleton, and we don't store any cache concurrency data
+    in the class, we check file existence and compute md5 digests every time we
+    service a request.
+    """
+    def __init__(self):
+        self.cachedir = None
+        self.log = get_logger(__name__)
+
+        calconf = get_calconf()
+        if calconf:
+            self.cachedir = calconf.get('system_calcache_dir')
+
+    def _fetchurltofile(self, url, filepath):
+        """
+        Fetch the contents of url and put them in a file at filepath
+        :param url: url to fetch
+        :param filepath: file to store contents in
+        :return: None
+        """
+        with open(filepath, 'wb') as fp:
+            r = requests.get(url, stream=True, timeout=10.0)
+            try:
+                r.raise_for_status()
+                for chunk in r.iter_content(chunk_size=None):
+                    fp.write(chunk)
+            except HTTPError as err:
+                raise GetterError(
+                    ["Could not retrieve {}".format(url), str(err)])
+            except ConnectionError as err:
+                raise GetterError(
+                    ["Unable to connect to url {}".format(url), str(err)])
+            except Timeout as terr:
+                raise GetterError(["Request timed out", str(terr)])
+
+    def get_request(self, url, filename, calmd5):
+        # This replaces the old calrequestlib.get_request() function
+        if url.startswith("file://"):
+            # If the URL is a local file, there's no point caching it anyway.
+            # Simply copy the file referenced in the URL to filename
+            urlfilepath = url.split('://', 1)[1]
+            shutil.copyfile(urlfilepath, filename)
+            return
+
+        if self.cachedir is None:
+            # Cache is disabled, Call requests to fetch URL, write data
+            # directly to filename
+            self._fetchurltofile(url, filename)
+            return
+
+        # Cache is enabled
+        # Is filename in cache?
+        cachefilename = os.path.join(self.cachedir, filename)
+        if os.path.exists(cachefilename):
+            # Does it have the correct md5?
+            cachemd5 = generate_md5_digest(cachefilename)
+            if cachemd5 == calmd5:
+                self.log.debug(f"Cache hit, copying {cachefilename} to "
+                               f"{filename}")
+                shutil.copyfile(cachefilename, filename)
+                return filename
+            else:
+                self.log.debug(f"Cache miss - file exists but wrong md5: "
+                               f"{cachemd5=}, {calmd5=}")
+        else:
+            self.log.debug(f"Cache miss - {filename} not in cache")
+        # Fetch the URL to the cache
+        self.log.debug(f"Fetching {url} to cache file {cachefilename}")
+        self._fetchurltofile(url, cachefilename)
+        # And copy it out to the destination
+        shutil.copyfile(cachefilename, filename)
+
 
 class GetterError(Exception):
     def __init__(self, messages):
         self.messages = messages
 
-def requests_getter(url):
-    r = requests.get(url, timeout=10.0)
-    try:
-        r.raise_for_status()
-        yield from r.iter_content(chunk_size=128)
-    except HTTPError as err:
-        raise GetterError(["Could not retrieve {}".format(url), str(err)])
-    except ConnectionError as err:
-        raise GetterError(["Unable to connect to url {}".format(url), str(err)])
-    except Timeout as terr:
-        raise GetterError(["Request timed out", str(terr)])
-
-def plain_file_getter(url):
-    path = url.split('://', 1)[1]
-    try:
-        with open(path, "rb") as source:
-            while True:
-                data = source.read(128)
-                if not data:
-                    break
-                yield data
-    except Exception as err:
-        raise GetterError(["Problem accessing to {}".format(url), str(err)])
-
-schema_mapper = {
-    'http': requests_getter,
-    'https': requests_getter,
-    'ftp': requests_getter,
-    'file': plain_file_getter
-    }
-
-def get_file_iterator(url):
-    getter = schema_mapper[url.split('://', 1)[0]]
-    return getter(url)

--- a/recipe_system/cal_service/file_getter.py
+++ b/recipe_system/cal_service/file_getter.py
@@ -61,12 +61,12 @@ class CachedFileGetter(object):
                     fp.write(chunk)
             except HTTPError as err:
                 raise GetterError(
-                    ["Could not retrieve {}".format(url), str(err)])
+                    ["Could not retrieve {}".format(url), str(err)]) from err
             except ConnectionError as err:
                 raise GetterError(
-                    ["Unable to connect to url {}".format(url), str(err)])
+                    ["Unable to connect to url {}".format(url), str(err)]) from err
             except Timeout as terr:
-                raise GetterError(["Request timed out", str(terr)])
+                raise GetterError(["Request timed out", str(terr)]) from terr
 
     def get_request(self, url, filename, calmd5):
         # This replaces the old calrequestlib.get_request() function

--- a/recipe_system/cal_service/file_getter.py
+++ b/recipe_system/cal_service/file_getter.py
@@ -42,7 +42,7 @@ class CachedFileGetter(object):
         self.cachedir = None
         self.log = get_logger(__name__)
 
-        calconf = globalConf.get('calibs')
+        calconf = globalConf['calibs']
         if calconf:
             self.cachedir = calconf.get('system_calcache_dir')
 
@@ -84,8 +84,8 @@ class CachedFileGetter(object):
             return
 
         # Cache is enabled
-        # Is filename in cache?
-        cachefilename = os.path.join(self.cachedir, filename)
+        # Is cachefilename in cache?
+        cachefilename = os.path.join(self.cachedir, os.path.basename(filename))
         if os.path.exists(cachefilename):
             # Does it have the correct md5?
             cachemd5 = generate_md5_digest(cachefilename)
@@ -98,7 +98,7 @@ class CachedFileGetter(object):
                 self.log.debug(f"Cache miss - file exists but wrong md5: "
                                f"{cachemd5=}, {calmd5=}")
         else:
-            self.log.debug(f"Cache miss - {filename} not in cache")
+            self.log.debug(f"Cache miss - {cachefilename} not in cache")
         # Fetch the URL to the cache
         self.log.debug(f"Fetching {url} to cache file {cachefilename}")
         self._fetchurltofile(url, cachefilename)

--- a/recipe_system/cal_service/file_getter.py
+++ b/recipe_system/cal_service/file_getter.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 from requests.exceptions import ConnectionError
 
-from . import get_calconf
+from ..config import globalConf
 from gempy.utils.logutils import get_logger
 from .calrequestlib import generate_md5_digest
 
@@ -42,7 +42,7 @@ class CachedFileGetter(object):
         self.cachedir = None
         self.log = get_logger(__name__)
 
-        calconf = get_calconf()
+        calconf = globalConf.get('calibs')
         if calconf:
             self.cachedir = calconf.get('system_calcache_dir')
 

--- a/recipe_system/cal_service/remotedb.py
+++ b/recipe_system/cal_service/remotedb.py
@@ -11,8 +11,8 @@ import urllib.parse
 import urllib.error
 
 from .caldb import CalDB, CalReturn
-from .calrequestlib import get_cal_requests, generate_md5_digest, get_request
-from .calrequestlib import GetterError
+from .calrequestlib import get_cal_requests, generate_md5_digest
+from .file_getter import GetterError, get_request
 
 UPLOADCOOKIE = "qap_upload_processed_cal_ok"
 
@@ -106,7 +106,7 @@ class RemoteDB(CalDB):
                 if not path.exists(caldir):
                     makedirs(caldir)
                 try:
-                    get_request(calurl, cachefile)
+                    get_request(calurl, cachefile, calmd5)
                 except GetterError as err:
                     for message in err.messages:
                         log.error(message)


### PR DESCRIPTION
This introduces an _optional_ system level cache for calibration file downloads. Most users will not need this and will not enable it. However it will make DRAGONS processing in GOA significantly more efficient.

If `system_calcache_dir` is defined in the `[calibs]` section of your `.dragonsrc`, then all calibration downloads from a `remoteDB` web server will be cached in this directory. If `system_calcache_dir` is not defined, no additional caching is introduced. For simplicity, no cache state is stored in the python code; cache hits and misses are purely on the presence and correct md5sum of files in the directory. I implemented this as a class to more easily allow implementation of more advanced cache features in the future should that become desirable, though in it's current form it could just be a function rather than a class if desired.

This is intended for use cases that will run several independent instances of DRAGONS in _different working directories_; either sequentially or simultaneously. Without this cache, each instance will download its own copy of the processed BPMs for example. GOA will do this extensively, which was the driver to implement this.

This PR also cleans up the `file_getter` code - eliminating for example file copies being implemented in bespoke python loops. 

This is completely independent of the "calibrations" subdirectory in the dragons working directory, which is referred to as a cache in the code. The cache implemented in this PR is in the code that downloads files to put them in those "calibrations" subdirectories.