### PR TITLE
Fix GUI callbacks

### DIFF
--- a/geminidr/core/primitives_telluric.py
+++ b/geminidr/core/primitives_telluric.py
@@ -241,7 +241,7 @@ class Telluric(Spect):
                 spline = make_interp_spline(tspek.waves[goodpix],
                                             absorption[goodpix], k=3)
                 spline.extrapolate = False  # will return np.nan outside range
-                ext.TELLABS = spline(tspek.waves)
+                ext.TELLABS = spline(tspek.waves).astype(ext.data.dtype)
                 #ext.TELLABS2 = absorption
 
             # We have to correct for exposure time and add the SENSFUNC units

--- a/geminidr/interactive/fit/fit1d.py
+++ b/geminidr/interactive/fit/fit1d.py
@@ -1745,9 +1745,7 @@ class Fit1DVisualizer(interactive.PrimitiveVisualizer):
                     self.make_modal(reinit_widgets[0], modal_message)
                     self.modal_widget = reinit_widgets[0]
             else:
-                reset_reinit_button = self.build_reset_button(
-                    extra_handler_fn=self.reconstruct_points
-                )
+                reset_reinit_button = self.build_reset_button()
                 reinit_widgets.append(reset_reinit_button)
 
             if recalc_inputs_above:

--- a/geminidr/interactive/interactive.py
+++ b/geminidr/interactive/interactive.py
@@ -284,16 +284,14 @@ class PrimitiveVisualizer(ABC):
 
             self.widgets[fname].update(**kwargs)
 
-            # This code is called when reinit_live has been set to False
-            # (to avoid repeated callbacks) so won't actually do anything
-            # # Update Text Field via callback function
-            # values = self.widgets[fname]._callbacks.get("value", [])
-            # for callback in values:
-            #     callback("value", old=old, new=reset_value)
-            #
-            # throt = self.widgets[fname]._callbacks.get("value_throttled", [])
-            # for callback in throt:
-            #     callback(attrib="value_throttled", old=old, new=reset_value)
+            # Update Text Field via callback function
+            values = self.widgets[fname]._callbacks.get("value", [])
+            for callback in values:
+                callback("value", old=old, new=reset_value)
+
+            throt = self.widgets[fname]._callbacks.get("value_throttled", [])
+            for callback in throt:
+                callback(attrib="value_throttled", old=old, new=reset_value)
 
     def build_reset_button(self, extra_handler_fn=None):
         reset_reinit_button = bm.Button(

--- a/gempy/library/calibrator.py
+++ b/gempy/library/calibrator.py
@@ -167,6 +167,7 @@ class TelluricCalibrator(Calibrator):
         return [tspek.mask.astype(bool) for tspek in self.spectra]
 
     def reconstruct_points(self, *args, **kwargs):
+        print("TelluricCalibrator.reconstruct_points()")
         print("REINIT", self.reinit_params)
         magnitude = self.reinit_params["magnitude"]
         w0, f0 = at.Magnitude(magnitude, abmag=self.reinit_params["abmag"]).properties()
@@ -213,6 +214,7 @@ class TelluricCalibrator(Calibrator):
             points masked in the fit
         """
         # Extract the fitting parameters for this panel
+        print("TelluricCalibrator.perform_fit()")
         params = {k: v[index] for k, v in self.fit_params.items()}
 
         # Start by updating fitting parameters to the value in the
@@ -225,6 +227,7 @@ class TelluricCalibrator(Calibrator):
 
     def perform_all_fits(self, sigma_clipping=None):
         """"""
+        print("")
         print("CALIBRATOR.PERFORM"+"-"*40)
         data = self.concatenate('data')
         mask = self.concatenate('mask').astype(bool)
@@ -289,6 +292,8 @@ class TelluricCalibrator(Calibrator):
             tspek.nddata.mask = orig_mask
 
         m_final.update_individual_models()
+        print("UDPATED MODELS")
+        print("")
         return m_final, new_mask
 
     # Methods above should be common to all classes


### PR DESCRIPTION
There was an issue with incorrect callbacks when resetting the GUI reinit_panel. The telluric GUI uniquely has widgets with immediate callbacks to fit the data and when the "reset" button reset these, it resulted in multiple fits. I had fixed this in a way which I thought did not affect other GUIs but the textboxes weren't being reset in other GUIs. There were other commits in this area so there may have been unflagged conflicts or I may have messed up.

Anyway, I believe that the GUIs now operate as expected on hitting "Reset". The fitTelluric() GUI only performs one fit as a flag is set upon hitting "Reset" which causes the callbacks to no-op.

I also coerced the TELLABS spectrum from fitTelluric() to have the same dtype as the SCI plane. It's constructed from a spline call which defaults to 64-bit.