### PR TITLE
Fix a couple of issues with findApertures

### DIFF
--- a/geminidr/interactive/fit/aperture.py
+++ b/geminidr/interactive/fit/aperture.py
@@ -1552,7 +1552,7 @@ def interactive_find_source_apertures(ext, ui_params=None, filename=None, **kwar
     if not filename and hasattr(ext, "orig_filename"):
         filename = ext.orig_filename
     fsav = FindSourceAperturesVisualizer(
-        model, ui_params=ui_params, filename_info=ext.filename
+        model, ui_params=ui_params, filename_info=filename
     )
     interactive_fitter(fsav)
     return fsav.result()

--- a/gempy/library/peak_finding.py
+++ b/gempy/library/peak_finding.py
@@ -969,7 +969,9 @@ def get_limits(data, mask=None, variance=None, peaks=[], threshold=0, min_snr=3,
         lower, upper = extrema[i-1][0], extrema[i+1][0]
         targets = [threshold * extrema[i][1] +
                    (1 - threshold) * extrema[j][1] for j in (i-1, i+1)]
-        i1, i2, p = int(lower), int(upper+1), int(true_peak+0.5)
+        # 0.999 is needed to avoid bringing in an extra pixel if the upper
+        # limit is the last pixel (or unmasked pixel) in the data
+        i1, i2, p = int(lower), int(upper+0.999), int(true_peak+0.5)
 
         limits = []
         for target, _slice in zip(targets, (slice(i1, p+2), slice(p-1, i2+1))):


### PR DESCRIPTION
1. There was an issue with aperture sizing if the rightmost aperture's minimum was the last pixel, or last unmasked pixel. The aperture could go all the way to the end of the data, depending on the extrapolation of the spline.
2. The filename didn't appear in the GUI.

These issues have been fixed.