### PR TITLE
Improve object cross-correlation for spectroscopy

### DIFF
--- a/geminidr/core/parameters_nearIR.py
+++ b/geminidr/core/parameters_nearIR.py
@@ -60,7 +60,7 @@ class cleanReadoutConfig(config.Config):
                                allowed={"default": "perform pattern removal if pattern in strong enough",
                                         "force": "force pattern removal",
                                         "skip": "skip primitive"},
-                               default="default", optional=False)
+                               default="skip", optional=False)
     debug_canny_sigma = config.RangeField("Standard deviation for smoothing of Canny edge-finding", float, 3, min=1)
 
 

--- a/geminidr/core/primitives_preprocess.py
+++ b/geminidr/core/primitives_preprocess.py
@@ -320,7 +320,6 @@ class Preprocess(PrimitivesBASE):
                                               if abs(sky_dict[k] - sci_time) <= seconds])
 
                     # Now create a sky list of the appropriate length
-                    print(ad.filename, num_matching_skies, min_skies, len(sky_dict), seconds)
                     if num_matching_skies < min_skies <= len(sky_dict):
                         log.warning(f"Found fewer skies ({num_matching_skies}) "
                                     "matching the time criterion than requested\n"

--- a/geminidr/gnirs/recipes/sq/recipes_IMAGE.py
+++ b/geminidr/gnirs/recipes/sq/recipes_IMAGE.py
@@ -28,7 +28,7 @@ def reduce(p):
     p.separateSky()
     p.associateSky()
     p.skyCorrect(mask_objects=False)
-    p.cleanReadout()
+    #p.cleanReadout()
     p.detectSources()
     p.adjustWCSToReference()
     p.resampleToCommonFrame()


### PR DESCRIPTION
The main change is to subtract the median value when constructing the slit profile for cross-correlation in `adjustWCSToReference()`, to prevent the cross-correlation function being dominated by the amount of slit overlap.

Also a make the `cleanReadout()` default "skip", and remove it from the GNIRS IMAGE recipe.