### PR TITLE
Handle slit flips when combining spectra. Tweak logging.

### DIFF
--- a/astrodata/nddata.py
+++ b/astrodata/nddata.py
@@ -105,12 +105,16 @@ class AstroDataMixin:
         for i, (slice_, length) in enumerate(zip(slices[::-1], self.shape[::-1])):
             model = []
             if isinstance(slice_, slice):
-                if slice_.step and slice_.step > 1:
+                if slice_.step and abs(slice_.step) > 1:
                     raise IndexError("Cannot slice with a step")
+                if slice_.step == -1:
+                    model.append(models.Scale(-1))
                 if slice_.start:
                     start = (length + slice_.start) if slice_.start < 0 else slice_.start
                     if start > 0:
                         model.append(models.Shift(start))
+                elif slice_.start is None and slice_.step == -1:
+                    model.append(models.Shift(length - 1))
                 mapped_axes.append(max(mapped_axes) + 1 if mapped_axes else 0)
             elif isinstance(slice_, INTEGER_TYPES):
                 model.append(models.Const1D((length + slice_) if slice_ < 0 else slice_))

--- a/astrodata/tests/test_nddata.py
+++ b/astrodata/tests/test_nddata.py
@@ -131,6 +131,9 @@ def test_wcs_slicing():
     assert nd[..., 10:].wcs(10, 10) == (20, 10)
     assert nd[:, 5].wcs(10) == (5, 10)
     assert nd[20, -10:].wcs(0) == (40, 20)
+    # and with flips
+    assert nd[::-1].wcs(10, 10) == (10, 39)
+    assert nd[:, ::-1].wcs(10, 10) == (39, 10)
 
 
 def test_access_to_other_planes(testnd):

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -491,6 +491,7 @@ class Spect(Resample):
                             aptable['aper_upper'] = aplow
 
                     new_sky_model = models.Shift(offset) | ref_sky_model_dict[iext]
+                    new_sky_model.name = 'SKY'
                     ext.wcs = am.replace_submodel_in_gwcs(ext.wcs, 'SKY', new_sky_model)
 
                 ad.phu['SLITOFF'] = offset

--- a/recipe_system/utils/decorators.py
+++ b/recipe_system/utils/decorators.py
@@ -288,6 +288,14 @@ def parameter_override(fn):
         # calling function contains a self that is also a primitive
         toplevel = _top_level_primitive()
 
+        # The first thing on the stack is the decorator, so check the name
+        # of the function calling that... don't indent or log if it's the
+        # same as this primitive.
+        try:
+            caller = inspect.stack()[1].function
+        except (AttributeError, IndexError):
+            caller = None
+
         # Start with the config file to get list of parameters
         # Copy to avoid permanent changes; shallow copy is OK
         if pname not in pobj.params:
@@ -300,7 +308,8 @@ def parameter_override(fn):
 
         # Find user parameter overrides
         params = userpar_override(pname, list(config), pobj.user_params)
-        set_logging(pname)
+        if caller != pname:
+            set_logging(pname)
 
         if toplevel:
             for k, v in kwargs.items():
@@ -370,7 +379,8 @@ def parameter_override(fn):
 
         if write_after:
             pobj.writeOutputs(stream=outstream)
-        unset_logging()
+        if caller != pname:
+            unset_logging()
         gc.collect()
         return ret_value
     return gn


### PR DESCRIPTION
1. Spectroscopic data can be taken with two slit orientations separated by 180 degrees. `adjustWCSToReference()` can now handle this. I've also added code so that `NDAstroData._slice_wcs()` creates a correct WCS when `slice.step==-1`.
2. I've tweaked the logging so that if a primitive `super()` calls a primitive with the same name, that call doesn't appear in the log.