### PR TITLE
Resolve unintended 64-bit outputs from primitives/tests and fix numdisplay on NumPy 2

### DIFF
--- a/geminidr/core/primitives_preprocess.py
+++ b/geminidr/core/primitives_preprocess.py
@@ -118,7 +118,7 @@ class Preprocess(PrimitivesBASE):
                                 "Continuing.")
                     continue
                 gain = gt.array_from_descriptor_value(ext, "gain")
-                ext.multiply(gain)
+                ext.multiply(np.float32(gain))  # avoid casting int to float64
 
                 # Update saturation and nonlinear levels with new value. We
                 # allowed these to return lists before this point but now a

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -3417,7 +3417,7 @@ class Spect(Resample):
                         sens_factor *= 10**(0.4 * delta_airmass * extinction_correction)
 
                 final_sens_factor = (sci_flux_unit * sens_factor / pixel_sizes).to(
-                    final_units, equivalencies=u.spectral_density(waves)).value
+                    final_units, equivalencies=u.spectral_density(waves)).value.astype(np.float32)
 
                 if ndim == 2 and dispaxis == 0:
                     ext *= final_sens_factor[:, np.newaxis]

--- a/geminidr/core/tests/test_preprocess.py
+++ b/geminidr/core/tests/test_preprocess.py
@@ -336,7 +336,7 @@ def test_fixpixels_with_file(niriprim, tmp_path):
 @pytest.mark.dragons_remote_data
 def test_fixpixels_3D(astrofaker):
     np.random.seed(42)
-    arr = np.arange(4 * 5 * 6, dtype=float).reshape(4, 5, 6)
+    arr = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
 
     # Shuffle the values to be sure the interpolation is done on the good axis
     # (when chacking the data below)
@@ -363,7 +363,7 @@ def test_fixpixels_3D(astrofaker):
 @pytest.mark.dragons_remote_data
 def test_fixpixels_3D_axis(astrofaker):
     np.random.seed(42)
-    arr = np.arange(4 * 5 * 6, dtype=float).reshape(4, 5, 6)
+    arr = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
 
     # Shuffle the values to be sure the interpolation is done on the good axis
     # (when chacking the data below)

--- a/geminidr/core/tests/test_spect.py
+++ b/geminidr/core/tests/test_spect.py
@@ -860,7 +860,7 @@ def create_zero_filled_fake_astrodata(height, width):
     """
     astrofaker = pytest.importorskip("astrofaker")
 
-    data = np.zeros((height, width))
+    data = np.zeros((height, width), dtype=np.float32)
 
     hdu = fits.ImageHDU()
     hdu.header['CCDSUM'] = "1 1"

--- a/geminidr/core/tests/test_stack.py
+++ b/geminidr/core/tests/test_stack.py
@@ -21,7 +21,7 @@ def f2_adinputs():
     phu = fits.PrimaryHDU()
     phu.header.update(OBSERVAT='Gemini-North', INSTRUME='F2',
                       ORIGNAME='S20010101S0001.fits')
-    data = np.ones((2, 2))
+    data = np.ones((2, 2), dtype=np.float32)
     adinputs = []
     for i in range(2):
         ad = astrodata.create(phu)
@@ -35,7 +35,7 @@ def niri_adinputs():
     phu = fits.PrimaryHDU()
     phu.header.update(OBSERVAT='Gemini-North', INSTRUME='NIRI',
                       ORIGNAME='N20010101S0001.fits')
-    data = np.ones((2, 2))
+    data = np.ones((2, 2), dtype=np.float32)
     adinputs = []
     for i in range(2):
         ad = astrodata.create(phu)
@@ -80,14 +80,14 @@ def test_error_only_one_file(niri_adinputs, caplog):
 
 def test_error_extension_number(niri_adinputs):
     p = NIRIImage(niri_adinputs)
-    niri_adinputs[1].append(np.zeros((2, 2)))
+    niri_adinputs[1].append(np.zeros((2, 2), dtype=np.float32))
     match = "Not all inputs have the same number of extensions"
     with pytest.raises(ValueError, match=match):
         p.stackFrames()
 
 
 def test_error_extension_shape(niri_adinputs, caplog):
-    niri_adinputs[1][0].data = np.zeros((3, 3))
+    niri_adinputs[1][0].data = np.zeros((3, 3), dtype=np.float32)
     p = NIRIImage(niri_adinputs)
     match = "Not all inputs images have the same shape"
     with pytest.raises(ValueError, match=match):
@@ -156,7 +156,7 @@ def test_stack_biases(rejection_method, expected, niri_image):
     adinputs = []
     for i in (0, 1, 2, 2, 3):
         ad = niri_image()
-        data = np.ones((2, 2)) * i
+        data = np.ones((2, 2), dtype=np.float32) * i
         ad[0].data = data
         ad.tags = ad.tags.union({'BIAS'})
         for ext in ad:

--- a/geminidr/ghost/primitives_ghost_slit.py
+++ b/geminidr/ghost/primitives_ghost_slit.py
@@ -380,7 +380,7 @@ class GHOSTSlit(GHOST):
             data, var, mask = _scale_and_stack(
                 all_data, all_var, all_mask, np.full((next,), 1./next))
             if operation == "median":  # we keep mask but modify data and var
-                data = np.median(all_data, axis=2)
+                data = np.median(all_data, axis=2).astype(data.dtype)
                 var *= 0.5 * np.pi  # according to Laplace (see nddops.py)
             adout.append(astrodata.NDAstroData(
                 data=data, mask=mask, meta={'header': hdr.copy()}))

--- a/geminidr/ghost/tests/spect/__init__.py
+++ b/geminidr/ghost/tests/spect/__init__.py
@@ -18,7 +18,8 @@ def ad_min():
     phu.header.set('CCDSUM', '1 1')
 
     # Create a simple data HDU with a zero BPM
-    sci = fits.ImageHDU(data=np.ones((1024, 1024,)), name='SCI')
+    sci = fits.ImageHDU(data=np.ones((1024, 1024,), dtype=np.float32),
+                        name='SCI')
     sci.header.set('CCDSUM', '1 1')
     sci.header.set('DATASEC', '[1:1024,1:1024]')
     sci.header.set('DETSEC', '[1:1024,1:1024]')

--- a/geminidr/ghost/tests/spect/test_dark_correct.py
+++ b/geminidr/ghost/tests/spect/test_dark_correct.py
@@ -32,7 +32,7 @@ def test_darkCorrect_rebin(ad_min, xbin, ybin):
     dark.filename = 'dark.fits'
 
     # 'Re-bin' the data file
-    ad_min[0].data = np.ones((int(1024 / ybin), int(1024 / xbin),), dtype=np.float64)
+    ad_min[0].data = np.ones((int(1024 / ybin), int(1024 / xbin),), dtype=np.float32)
     ad_min[0].hdr.set('CCDSUM', '{} {}'.format(xbin, ybin, ))
 
     gs = GHOSTSpect([])

--- a/geminidr/gmos/primitives_gmos_image.py
+++ b/geminidr/gmos/primitives_gmos_image.py
@@ -527,7 +527,8 @@ class GMOSImage(GMOS, Image, Photometry):
 
             if calc_scaling:
                 # weight by number of samples in each slice
-                bg_measurements = [np.asarray(m) for m in bg_measurements]
+                bg_measurements = [np.asarray(m, dtype=np.float32)
+                                   for m in bg_measurements]
                 bg_levels = [np.average(m[:, 0], weights=m[:, 1])
                              for m in bg_measurements]
                 log.debug("{} background levels: {:.3f}, {:.3f}, {:.3f}".
@@ -558,7 +559,9 @@ class GMOSImage(GMOS, Image, Photometry):
         # factors for all inputs, calculate and apply that now
         if calc_scaling and common and ads_to_correct:
             scale_factors = 1 / np.average(
-                np.asarray(scalings), weights=np.asarray(scaling_samples), axis=0)
+                np.asarray(scalings), weights=np.asarray(scaling_samples),
+                axis=0
+            ).astype(np.float32)
             log.stdinfo("Calculated scale factors of {:.3f}, {:.3f} for all "
                         "inputs".format(*scale_factors))
             for ad in ads_to_correct:

--- a/geminidr/gmos/primitives_gmos_longslit.py
+++ b/geminidr/gmos/primitives_gmos_longslit.py
@@ -436,9 +436,9 @@ class GMOSClassicLongslit(GMOSSpect, Longslit):
             rows_val, cols_val = \
                 np.mgrid[-border:height+border, -border:width+border]
 
-            slit_response_data = model_2d_data(cols_val, rows_val)
+            slit_response_data = model_2d_data(cols_val, rows_val).astype(np.float32)
             slit_response_mask = np.pad(mask, border, mode='edge')  # ToDo: any update to the mask?
-            slit_response_std = model_2d_std(cols_val, rows_val)
+            slit_response_std = model_2d_std(cols_val, rows_val).astype(np.float32)
             slit_response_var = slit_response_std ** 2
 
             del cols_fit, cols_val, rows_fit, rows_val

--- a/geminidr/gmos/tests/image/test_qe_correct.py
+++ b/geminidr/gmos/tests/image/test_qe_correct.py
@@ -42,7 +42,8 @@ def test_qe_correct_calculate_and_apply_scaling(adinputs, common):
     for i, (adin, adout) in enumerate(zip(safe_adinputs, p.streams['main'])):
         for j, (extin, extout) in enumerate(zip(adin, adout)):
             scaling = correct_scaling[common][i][j // 4]
-            np.testing.assert_allclose(extin.data * scaling, extout.data)
+            np.testing.assert_allclose(extin.data * scaling, extout.data,
+                                       rtol=2e-7)
 
 
 @pytest.fixture(scope="function")

--- a/geminidr/gmos/tests/longslit/test_slit_illum_correct.py
+++ b/geminidr/gmos/tests/longslit/test_slit_illum_correct.py
@@ -297,7 +297,7 @@ def create_twilight_inputs():
     }
 
     root_path = os.path.join("./dragons_test_inputs/")
-    module_path = "geminidr/gmos/longslit/test_slit_illumination_correct/inputs"
+    module_path = "geminidr/gmos/longslit/test_slit_illum_correct/inputs"
     path = os.path.join(root_path, module_path)
     os.makedirs(path, exist_ok=True)
     cwd = os.getcwd()

--- a/geminidr/gmos/tests/spect/test_find_source_apertures.py
+++ b/geminidr/gmos/tests/spect/test_find_source_apertures.py
@@ -13,6 +13,7 @@ import astrodata
 import gemini_instruments
 
 from astropy.modeling.models import Gaussian1D
+from geminidr.gemini.lookups import DQ_definitions as DQ
 from geminidr.gmos.primitives_gmos_spect import GMOSSpect
 
 test_data = [
@@ -97,10 +98,10 @@ def test_find_apertures_with_fake_data(peak_position, peak_value, seeing, astrof
     rows, cols = np.mgrid[:ad.shape[0][0], :ad.shape[0][1]]
 
     for ext in ad:
-        ext.data = model(rows)
+        ext.data = model(rows).astype(np.float32)
         ext.data += np.random.poisson(ext.data)
         ext.data += np.random.normal(scale=gmos_fake_noise, size=ext.shape)
-        ext.mask = np.zeros_like(ext.data, dtype=np.uint)
+        ext.mask = np.zeros_like(ext.data, dtype=DQ.datatype)
 
     p = GMOSSpect([ad])
     _ad = p.findApertures(max_apertures=1, min_snr=3)[0]
@@ -352,8 +353,8 @@ def create_inputs_automated_recipe():
         sn_std = 0.42466 * sn_fwhm
         model = (Gaussian1D(amplitude=peak, mean=yc, stddev=gal_std) +
                  Gaussian1D(amplitude=peak * contrast, mean=yc + sep, stddev=sn_std))
-        profile = model(np.arange(SHAPE[0]))
-        data = np.zeros(SHAPE) + profile[:, np.newaxis]
+        profile = model(np.arange(SHAPE[0])).astype(np.float32)
+        data = np.zeros(SHAPE, dtype=np.float32) + profile[:, np.newaxis]
         data += np.random.normal(scale=RDNOISE, size=data.size).reshape(data.shape)
 
         hdulist = pf.HDUList([pf.PrimaryHDU(header=pf.Header(phu_dict)),

--- a/geminidr/gmos/tests/spect/test_find_source_apertures.py
+++ b/geminidr/gmos/tests/spect/test_find_source_apertures.py
@@ -57,7 +57,7 @@ extra_test_data.extend([
 
 # Some iterations are known to be failure cases
 # we mark them accordingly so we can see if they start passing
-_xfail_indices = (0, 1, 5, 6, 9, 17, 20, 24, 25, 29)
+_xfail_indices = (0, 4, 13, 20, 21, 25, 29)
 for idx in _xfail_indices:
     args = extra_test_data[idx]
     extra_test_data[idx] = pytest.param(args, marks=pytest.mark.xfail)

--- a/geminidr/gmos/tests/spect/test_flux_calibration.py
+++ b/geminidr/gmos/tests/spect/test_flux_calibration.py
@@ -66,7 +66,7 @@ def test_flux_calibration_with_fake_data():
 
         spline = BSpline(std_wavelength, std_flux, 3)
         wavelength = np.linspace(std_wavelength.min(), std_wavelength.max(), 1000)
-        flux = spline(wavelength)
+        flux = spline(wavelength).astype(np.float32)
         return wavelength, flux
 
     def _create_fake_data(object_name):

--- a/geminidr/gmos/tests/spect/test_resample_2d.py
+++ b/geminidr/gmos/tests/spect/test_resample_2d.py
@@ -59,7 +59,7 @@ def test_resampling(adinputs, caplog, offset):
     assert abs(adout[2].phu['SLITOFF'] + 2 * offset) < 0.001
 
     p.resampleToCommonFrame(dw=0.15)
-    wpars = 'w1=508.343 w2=1088.393 dw=0.150 npix=3868'
+    wpars = 'w1=508.273 w2=1088.323 dw=0.150 npix=3868'
     assert any(wpars in record.message for record in caplog.records)
     assert all(ad[0].shape == (int(512 - 2*offset), 3868) for ad in p.streams['main'])
 
@@ -76,7 +76,7 @@ def test_resampling_and_trim(adinputs, caplog, offset):
     assert abs(adout[2].phu['SLITOFF'] + 2 * offset) < 0.001
 
     p.resampleToCommonFrame(dw=0.15, trim_spectral=True)
-    wpars = 'w1=614.812 w2=978.862 dw=0.150 npix=2428'
+    wpars = 'w1=614.787 w2=978.837 dw=0.150 npix=2428'
     assert any(wpars in record.message for record in caplog.records)
     for ad in p.streams['main']:
         assert ad[0].shape == (int(512 - 2*offset), 2428)
@@ -127,12 +127,12 @@ def test_resampling_non_linearize(adinputs, caplog):
     assert adout[2].phu['SLITOFF'] == -20
 
     p.resampleToCommonFrame(output_wave_scale="reference", trim_spectral=True)
-    wpars = 'w1=614.870 w2=978.802 dw=0.151 npix=2407'
+    wpars = 'w1=614.835 w2=978.758 dw=0.151 npix=2407'
     assert any(wpars in record.message for record in caplog.records)
     caplog.clear()
     adout = p.resampleToCommonFrame(dw=0.15)
     assert 'ALIGN' in adout[0].phu
-    wpars = 'w1=614.870 w2=978.920 dw=0.150 npix=2428'
+    wpars = 'w1=614.835 w2=978.885 dw=0.150 npix=2428'
     assert any(wpars in record.message for record in caplog.records)
 
     adstack = p.stackFrames()
@@ -225,7 +225,7 @@ def create_inputs_recipe():
         else:
             p = GMOSLongslit([astrodata.open(arc_path)])
             p.prepare()
-            p.addDQ(static_bpm=None)
+            p.addDQ()
             p.addVAR(read_noise=True)
             p.overscanCorrect()
             p.ADUToElectrons()
@@ -245,7 +245,6 @@ def create_inputs_recipe():
         p.overscanCorrect()
         p.ADUToElectrons()
         p.addVAR(poisson_noise=True)
-        p.mosaicDetectors()
         p.attachWavelengthSolution(arc=arc)
         p.distortionCorrect()
         p.findApertures(max_apertures=1)

--- a/geminidr/gmos/tests/spect/test_write_1d_spectra.py
+++ b/geminidr/gmos/tests/spect/test_write_1d_spectra.py
@@ -60,7 +60,7 @@ def test_write_spectrum_various_units(ad, xunits, yunits, change_working_dir, ca
                                       for r in caplog.records)
         assert mismatched_units == unit_conversion_failure
         t = Table.read(ad.filename.replace(".fits", "_001.dat"),
-                       format="ascii.basic")
+                       format="ascii.basic")  # defaults to float64
         assert len(t) == ad[0].data.size
         assert len(t.colnames) == 3
         # Confirm wavelength has been converted
@@ -68,7 +68,8 @@ def test_write_spectrum_various_units(ad, xunits, yunits, change_working_dir, ca
             (w0 * 10) if xunits == 'AA'  else w0)
         # Confirm S/N is preserved
         np.testing.assert_allclose(np.sqrt(ad[0].variance) / ad[0].data,
-                                   np.sqrt(t['variance']) / t['data'], rtol=2e-7)
+                                   np.sqrt(t['variance']) / t['data'],
+                                   rtol=2e-7, atol=1.2e-7)
 
 
 

--- a/gempy/gemini/gemini_tools.py
+++ b/gempy/gemini/gemini_tools.py
@@ -1617,6 +1617,7 @@ def measure_bg_from_image(ad, sampling=10, value_only=False, gaussfit=True,
                 bg_data = bg_data.data[~bg_data.mask]
                 bg = np.median(bg_data)
                 bg_std = np.std(bg_data)
+            bg, bg_std = float(bg), float(bg_std)  # allow weak type promotion
         else:
             bg, bg_std = None, None
 

--- a/gempy/gemini/gemini_tools.py
+++ b/gempy/gemini/gemini_tools.py
@@ -1562,6 +1562,8 @@ def measure_bg_from_image(ad, sampling=10, value_only=False, gaussfit=True,
         or (bg, std, number of samples) tuple; otherwise returns a list of
         such things
     """
+    log = logutils.get_logger(__name__)
+
     # Handle NDData objects (or anything with .data and .mask attributes
     maxiter = 10
     try:
@@ -1593,25 +1595,36 @@ def measure_bg_from_image(ad, sampling=10, value_only=False, gaussfit=True,
         else:
             bg_data = bg_data[flags.ravel() == 0][::sampling]
 
+        do_gaussfit = gaussfit
+
         if len(bg_data) > 1:
-            if gaussfit:
+            if do_gaussfit:
                 lsigma, hsigma = 3, 1
                 bg, bg_std = sigma_clipped_stats(bg_data, sigma=5, maxiters=5)[1:]
                 niter = 0
                 while True:
                     iter_data = np.sort(bg_data[np.logical_and(bg-lsigma*bg_std < bg_data,
-                                                               bg+hsigma*bg_std > bg_data)][::sampling])
+                                                               bg+hsigma*bg_std >= bg_data)][::sampling])
                     oldbg, oldbg_std = bg, bg_std
                     g_init = Ogive(bg, bg_std, lsigma, hsigma)
                     g_init.lsigma.fixed = True
                     g_init.hsigma.fixed = True
                     fit_g = fitting.LevMarLSQFitter()
-                    g = fit_g(g_init, iter_data, np.linspace(0., 1., iter_data.size + 1)[1:])
+                    try:
+                        g = fit_g(g_init, iter_data, np.linspace(0., 1., iter_data.size + 1)[1:])
+                    except Exception as err:
+                        do_gaussfit = False
+                        log.warning(
+                            f"measure_bg_from_image: fitting failed; "
+                            f"falling back to gaussfit=False instead.\n"
+                            f"Error was: {err}"
+                        )
+                        break
                     bg, bg_std = g.mean.value, abs(g.stddev.value)
                     if abs(bg - oldbg) < 0.001 * bg_std or niter > maxiter:
                         break
                     niter += 1
-            else:
+            if not do_gaussfit:
                 # Sigma-clipping will screw up the stats of course!
                 bg_data = sigma_clip(bg_data[::sampling], sigma=2.0, maxiters=2)
                 bg_data = bg_data.data[~bg_data.mask]

--- a/gempy/library/astrotools.py
+++ b/gempy/library/astrotools.py
@@ -227,7 +227,7 @@ def calculate_scaling(x, y, sigma_x=None, sigma_y=None, sigma=3, niter=2):
         fitting.LinearLSQFitter(), outlier_func=stats.sigma_clip, niter=niter,
         sigma=sigma)
     m_final, _ = fit_it(m_init, x, y, weights=weights)
-    return m_final.factor.value
+    return float(m_final.factor.value)  # don't force upcasting in N2 arith.
 
 
 def divide0(numerator, denominator):

--- a/gempy/library/transform.py
+++ b/gempy/library/transform.py
@@ -1747,13 +1747,14 @@ def resample_from_wcs(ad, frame_name, attributes=None, interpolant="linear",
 
         # array_section only has meaning now if the inputs were from a
         # single physical array
-        if len(blocks) == 1:
-            all_arrsec = np.array([ext.array_section() for ext in ad]).T
-            ad_out.hdr[keywords['array']] = \
-                '[' + ','.join('{}:{}'.format(min(c1) + 1, max(c2))
-                               for c1, c2 in zip(all_arrsec[::2], all_arrsec[1::2])) + ']'
-        else:
-            del ad_out.hdr[keywords['array']]
+        if keywords['array'] in ad_out.hdr:
+            if len(blocks) == 1:
+                all_arrsec = np.array([ext.array_section() for ext in ad]).T
+                ad_out.hdr[keywords['array']] = \
+                    '[' + ','.join('{}:{}'.format(min(c1) + 1, max(c2))
+                                   for c1, c2 in zip(all_arrsec[::2], all_arrsec[1::2])) + ']'
+            else:
+                del ad_out.hdr[keywords['array']]
 
     # Try to assign an array name for this based on commonality
     if not is_single:

--- a/gempy/numdisplay/displaydev.py
+++ b/gempy/numdisplay/displaydev.py
@@ -383,7 +383,7 @@ class ImageDisplay:
         nbytes = pix.size * pix.itemsize
         self._writeHeader(opcode,self._MEMORY, -nbytes, x, y, frame, 0)
 
-        status = self._write(pix.tostring())
+        status = self._write(pix.tobytes())
         return status
 
     def readData(self,x,y,pix):
@@ -539,12 +539,12 @@ class ImageDisplay:
 
         """Write request to image display"""
 
-        a = n.array([tid,thingct,subunit,0,x,y,z,t],dtype=n.uint16)
+        a = n.array([tid,thingct,subunit,0,x,y,z,t],dtype=int).astype(n.uint16)
         # Compute the checksum
         sum = n.add.reduce(a,dtype=n.uint16)
         sum = 0xffff - (sum & 0xffff)
         a[3] = sum
-        self._write(a.tostring())
+        self._write(a.tobytes())
 
     def close(self, os_close=os.close):
 

--- a/recipe_system/utils/decorators.py
+++ b/recipe_system/utils/decorators.py
@@ -359,6 +359,7 @@ def parameter_override(fn):
                 try:
                     fnargs = dict(config.items())
                     ret_value = fn(pobj, adinputs=adinputs, **fnargs)
+                    assert_expected_dtypes(ret_value)
                 except Exception:
                     zeroset()
                     raise
@@ -373,6 +374,7 @@ def parameter_override(fn):
                         raise TypeError("Single AstroData instance passed to "
                                         "primitive, should be a list")
                     ret_value = fn(pobj, adinputs=adinputs, **dict(config.items()))
+                    assert_expected_dtypes(ret_value)
                 except Exception:
                     zeroset()
                     raise
@@ -384,3 +386,34 @@ def parameter_override(fn):
         gc.collect()
         return ret_value
     return gn
+
+
+# Enforce the expected dtypes between primitives, to catch NumPy 2 issues:
+def assert_expected_dtypes(adinputs):
+    msg = ""
+    for ad in adinputs:
+        for n, ext in enumerate(ad):
+            emsg = f'  File {ad.filename}, AstroData ext {n}:\n'
+            initlen = len(emsg)
+            ndd = ext.nddata
+            if ndd.data.dtype.itemsize > 4:  # int/float with max 32 bits
+                emsg += f'    data:        {ndd.data.dtype}\n'
+            if ndd.uncertainty is not None and (
+                ndd.uncertainty.array.dtype.kind != 'f' or
+                ndd.uncertainty.array.dtype.itemsize != 4  # expect float32
+            ):
+                emsg += f'    uncertainty: {ndd.data.dtype}\n'
+            if ndd.mask is not None and (
+                ndd.mask.dtype.kind != 'u' or
+                ndd.mask.dtype.itemsize > 2  # uint16 for Gemini data; OK?
+            ):
+                emsg += f'    mask:        {ndd.mask.dtype}\n'
+            # The other attribute that gets to >1MB in practice is OBJMASK:
+            if hasattr(ext, 'OBJMASK') and ext.OBJMASK.dtype.itemsize > 1:
+                mesg += f'    OBJMASK:     {ext.OBJMASK.dtype}\n'
+            if len(emsg) > initlen:
+                msg += emsg
+    if msg:
+        raise AssertionError(
+            f'Produced unexpected output data type(s):\n\n{msg}'
+        )

--- a/recipe_system/utils/decorators.py
+++ b/recipe_system/utils/decorators.py
@@ -402,7 +402,7 @@ def assert_expected_dtypes(adinputs):
                 ndd.uncertainty.array.dtype.kind != 'f' or
                 ndd.uncertainty.array.dtype.itemsize != 4  # expect float32
             ):
-                emsg += f'    uncertainty: {ndd.data.dtype}\n'
+                emsg += f'    uncertainty: {ndd.uncertainty.array.dtype}\n'
             if ndd.mask is not None and (
                 ndd.mask.dtype.kind != 'u' or
                 ndd.mask.dtype.itemsize > 2  # uint16 for Gemini data; OK?

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
     which pip
     which pytest
     pip install wheel
-    pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker#egg=AstroFaker
+    pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker@numpy_2c
     pip install /rtfproc/tmp/astropy-7.2.dev254+g27d1eb6fd9-cp312-cp312-linux_x86_64.whl
     conda list
     noop: python -c "pass"  # just install deps & ensure python runs

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ conda_deps =
     jinja2>=3.0
     jsonschema>=3.0
     matplotlib>=3.7
-    numpy>=1.24,<2.0.0a0
+    numpy>=1.24
     objgraph>=3.5
     pandas>=2.0
     psutil>=5.6  # only used by adcc?
@@ -73,6 +73,7 @@ commands =
     which pytest
     pip install wheel
     pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker#egg=AstroFaker
+    pip install /rtfproc/tmp/astropy-7.2.dev254+g27d1eb6fd9-cp312-cp312-linux_x86_64.whl
     conda list
     noop: python -c "pass"  # just install deps & ensure python runs
     unit: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "not integration_test and not gmos and not gmosls and not gmosimage and not f2 and not f2ls and not f2image and not gsaoi and not niri and not nirils and not niriimage and not gnirs and not gnirsls and not gnirsimage and not gnirsxd and not wavecal and not regression and not slow and not ghost and not ghostbundle and not ghostslit and not ghostspect" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ conda_deps =
     jinja2>=3.0
     jsonschema>=3.0
     matplotlib>=3.7
-    numpy>=1.24
+    numpy>=1.24,<2.0.0a0
     objgraph>=3.5
     pandas>=2.0
     psutil>=5.6  # only used by adcc?
@@ -72,8 +72,7 @@ commands =
     which pip
     which pytest
     pip install wheel
-    pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker@numpy_2c
-    pip install /rtfproc/tmp/astropy-7.2.dev254+g27d1eb6fd9-cp312-cp312-linux_x86_64.whl
+    pip install --no-use-pep517 git+https://github.com/GeminiDRSoftware/AstroFaker@numpy_2
     conda list
     noop: python -c "pass"  # just install deps & ensure python runs
     unit: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "not integration_test and not gmos and not gmosls and not gmosimage and not f2 and not f2ls and not f2image and not gsaoi and not niri and not nirils and not niriimage and not gnirs and not gnirsls and not gnirsimage and not gnirsxd and not wavecal and not regression and not slow and not ghost and not ghostbundle and not ghostslit and not ghostspect" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}


### PR DESCRIPTION
This resolves all unintended-dtype violations when running the Jenkins tests with a decorator trap, on both NumPy 1 & 2. It covers cases where primitives were upcasting their inputs to 64 bits (either all along or just on NumPy 2) and tests that were inadvertently using 64-bit (mostly-artificial) inputs, which propagated to the outputs of the primitive being tested.

A pending fix is also included to make `numdisplay` work on NumPy 2.

This branch is the same as `numpy_2c`, where I've been working, except that it continues testing on NumPy 1 for now, without my NDData  [#18392](https://github.com/astropy/astropy/pull/18392) patches, until such time as those get merged into AstroPy.

The decorator trap has been left in place for for the time being, as suggested by @chris-simpson, to avoid unintended dtypes being produced during further development. We may, however, want to revisit this before making a new release branch, as it would currently prevent users from _deliberately_ propagating 64-bit data (eg. it might be better to require that primitives don't upcast their inputs to 64 bits, rather than explicitly requiring their outputs to have no more than 32 bits).