### PR TITLE
Enh/check processed arc - add monitorWavelengthSolution primitive and associated qa recipes

### DIFF
--- a/geminidr/core/parameters_spect.py
+++ b/geminidr/core/parameters_spect.py
@@ -579,6 +579,8 @@ class maskBeyondSlitConfig(config.Config):
         "Minimum fraction of pixel that must be illuminated to not be masked",
         float, 0.9, min=0., max=1., inclusiveMax=True)
 
+class monitorWavelengthSolutionConfig(config.Config):
+    suffix = config.Field("Filename suffix", str, "_wavelengthSolutionMonitoring", optional=True)
 
 class normalizeFlatConfig(config.core_1Dfitting_config):
     suffix = config.Field("Filename suffix", str, "_normalized", optional=True)

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -3991,6 +3991,49 @@ class Spect(Resample):
 
         return adinputs
 
+    def monitorWavelengthSolution(self, adinputs=None, **params):
+        """
+        This captures some info from the wavelength solution for the GOA
+        instrument monitoring system into various MWS_ headers for the instrument
+        monitoring system to pick up.
+
+        Values Captured include the polynomial coefficients and RMS from the
+        .WAVECAL table, the central wavelength from both the WCS and central_wavlength()
+        descriptor and the difference between them.
+        :return:
+        """
+        log = self.log
+        log.debug(gt.log_message("primitive", self.myself(), "starting"))
+
+        tocapture = ('c0', 'c1', 'c2', 'c3', 'rms')
+
+        for ad in adinputs:
+            for ext in ad:
+                wavecal = getattr(ext, 'WAVECAL', None)
+                if wavecal is None:
+                    continue
+
+                for row in wavecal:
+                    if row['name'] in tocapture:
+                        keyword = 'MWS_' + row['name'].upper()
+                        ext.hdr[keyword] = (row['coefficients'],
+                                            f'WAVECAL {row['name']} coefficient')
+
+                # Get the wavelength of the central pixel
+                cp_x = ext.shape[0] / 2
+                cp_y = ext.shape[1] / 2
+
+                wcs_cent_nm = ext.wcs.pixel_to_world(cp_y, cp_x)[0].nm
+                hdr_cent_nm = ad.central_wavelength(asNanometers=True)
+                ext.hdr['MWS_WCS'] = (wcs_cent_nm, 'WCS solution central wavelength [nm]')
+                ext.hdr['MWS_HDR'] = (hdr_cent_nm, 'Header central wavelength [nm]')
+                ext.hdr['MWS_DIFF'] = (hdr_cent_nm - wcs_cent_nm,
+                                      'Difference between header and WCS central wavelengths')
+
+
+            ad.update_filename(suffix=params["suffix"], strip=True)
+
+        return adinputs
 
     def normalizeFlat(self, adinputs=None, **params):
         """

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -4014,32 +4014,67 @@ class Spect(Resample):
                 if wavecal is None:
                     continue
 
+                # We capture the coeffs into a dict for later use
+                coeffs = {}
                 for row in wavecal:
                     if row['name'] in tocapture:
                         keyword = 'MWS_' + row['name'].upper()[:4]
                         ext.hdr[keyword] = (row['coefficients'],
                                             f'WAVECAL {row['name']} coefficient')
-                        if row['name'] == 'c0':
-                            # compare c0 with central_wavelength
-                            c0init = ext.central_wavelength(asNanometers=True)
-                            ext.hdr['MWS_C0DE'] = (row['coefficients'] - c0init,
-                                                   'Delta between c0 and central_wavelength')
-                        elif row['name'] == 'c1':
-                            # compare c1 with dispersion
+                        m = re.match(r'^c(\d+)$', row['name'])
+                        if m:
+                            coeffs[int(m.groups()[0])] = row['coefficients']
 
-                            # following waveval.py get_all_input_data
-                            dispaxis = 2 - ext.dispersion_axis()  # python sense
-                            center = int(0.5 * (ext.shape[1 - dispaxis] - 1))
-                            if dispaxis == 1:
-                                _slice = (center, slice(None))
-                            else:
-                                _slice = (slice(None), center)
-                            ndd = ext.nddata[_slice]
-                            npix = ndd.shape[0]
+                # compare model with central_wavelength
+                # Per Chris, central wavelength of the model is c0-c2+c4-c6...
+                # Alternatively, we could evaluate the WCS at the central pixel.
+                # Calculate the model central wavelength from the coefficients
+                i=0
+                sign = 1
+                model_central_wlen = 0
+                while(True):
+                    try:
+                        model_central_wlen += sign * coeffs[i]
+                    except KeyError:
+                        break
+                    sign *= -1
+                    i += 2
 
-                            c1init = 0.5 * (npix - 1) * ext.dispersion(asNanometers=True)
-                            ext.hdr['MWS_C1DE'] = (row['coefficients'] - c1init,
-                                                   'Delta between c1 and 0.5*dispersion')
+                header_central_wlen = ext.central_wavelength(asNanometers=True)
+
+                ext.hdr['MWS_CWLE'] = (model_central_wlen - header_central_wlen,
+                                                   'Delta between model and header central_wavelength')
+
+                # The initial estimate of c0 is the central wavelength (because
+                # the initial estimate of c2 is 0). Record the change
+                try:
+                    ext.hdr['MWS_C0DE'] = (coeffs[0] - ext.central_wavelength(asNanometers=True),
+                                           'Delta between c0 and central_wavelength')
+                except KeyError:
+                    pass
+
+                # compare c1 with dispersion
+                # following waveval.py get_all_input_data
+                dispaxis = 2 - ext.dispersion_axis()  # python sense
+                center = int(0.5 * (ext.shape[1 - dispaxis] - 1))
+                if dispaxis == 1:
+                    _slice = (center, slice(None))
+                else:
+                    _slice = (slice(None), center)
+                ndd = ext.nddata[_slice]
+                npix = ndd.shape[0]
+
+                try:
+                    model_dispersion = 0.5 * (npix - 1) / coeffs[1]
+                    header_dispersion = ext.dispersion(asNanometers=True)
+                    ext.hdr['MWS_DISE'] = (model_dispersion - header_dispersion,
+                                                       'Delta model and header dispersion')
+
+                    c1init = 0.5 * (npix - 1) * ext.dispersion(asNanometers=True)
+                    ext.hdr['MWS_C1DE'] = (coeffs[1] - c1init,
+                                           'Delta between c1 and 0.5*dispersion')
+                except KeyError:
+                    pass
 
                 # Count the number of arc lines in the wavecal table
                 ext.hdr['MWS_NUML'] = (numpy.count_nonzero(wavecal['peaks']),

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -4014,67 +4014,30 @@ class Spect(Resample):
                 if wavecal is None:
                     continue
 
-                # We capture the coeffs into a dict for later use
-                coeffs = {}
                 for row in wavecal:
+                    # Capture values from WAVEVAL table into monitoring headers
                     if row['name'] in tocapture:
                         keyword = 'MWS_' + row['name'].upper()[:4]
                         ext.hdr[keyword] = (row['coefficients'],
                                             f'WAVECAL {row['name']} coefficient')
-                        m = re.match(r'^c(\d+)$', row['name'])
-                        if m:
-                            coeffs[int(m.groups()[0])] = row['coefficients']
 
-                # compare model with central_wavelength
-                # Per Chris, central wavelength of the model is c0-c2+c4-c6...
-                # Alternatively, we could evaluate the WCS at the central pixel.
-                # Calculate the model central wavelength from the coefficients
-                i=0
-                sign = 1
-                model_central_wlen = 0
-                while(True):
-                    try:
-                        model_central_wlen += sign * coeffs[i]
-                    except KeyError:
-                        break
-                    sign *= -1
-                    i += 2
+                # Get the model and evaluate it at the mean of its domain
+                model = am.get_named_submodel(ext.wcs.forward_transform, "WAVE")
+                if model:
+                    # Central Wavelength check
+                    center = np.mean(model.domain)
+                    model_central_wlen = model(center)
+                    header_central_wlen = ext.central_wavelength(asNanometers=True)
 
-                header_central_wlen = ext.central_wavelength(asNanometers=True)
+                    ext.hdr['MWS_DCWL'] = (model_central_wlen - header_central_wlen,
+                                           'Delta between model and header central_wavelength')
 
-                ext.hdr['MWS_CWLE'] = (model_central_wlen - header_central_wlen,
-                                                   'Delta between model and header central_wavelength')
-
-                # The initial estimate of c0 is the central wavelength (because
-                # the initial estimate of c2 is 0). Record the change
-                try:
-                    ext.hdr['MWS_C0DE'] = (coeffs[0] - ext.central_wavelength(asNanometers=True),
-                                           'Delta between c0 and central_wavelength')
-                except KeyError:
-                    pass
-
-                # compare c1 with dispersion
-                # following waveval.py get_all_input_data
-                dispaxis = 2 - ext.dispersion_axis()  # python sense
-                center = int(0.5 * (ext.shape[1 - dispaxis] - 1))
-                if dispaxis == 1:
-                    _slice = (center, slice(None))
-                else:
-                    _slice = (slice(None), center)
-                ndd = ext.nddata[_slice]
-                npix = ndd.shape[0]
-
-                try:
-                    model_dispersion = 0.5 * (npix - 1) / coeffs[1]
+                    # Dispersion check
+                    model_dispersion = model(center+0.5) - model(center-0.5)
                     header_dispersion = ext.dispersion(asNanometers=True)
-                    ext.hdr['MWS_DISE'] = (model_dispersion - header_dispersion,
-                                                       'Delta model and header dispersion')
+                    ext.hdr['MWS_DDIS'] = (model_dispersion - header_dispersion,
+                                           'Delta between model and header dispersion')
 
-                    c1init = 0.5 * (npix - 1) * ext.dispersion(asNanometers=True)
-                    ext.hdr['MWS_C1DE'] = (coeffs[1] - c1init,
-                                           'Delta between c1 and 0.5*dispersion')
-                except KeyError:
-                    pass
 
                 # Count the number of arc lines in the wavecal table
                 ext.hdr['MWS_NUML'] = (numpy.count_nonzero(wavecal['peaks']),

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -4027,7 +4027,8 @@ class Spect(Resample):
                     # Central Wavelength check
                     center = np.mean(model.domain)
                     model_central_wlen = model(center)
-                    header_central_wlen = ext.central_wavelength(asNanometers=True)
+                    # We want actual_central_wavelength rather than central_wavelength
+                    header_central_wlen = ext.actual_central_wavelength(asNanometers=True)
 
                     ext.hdr['MWS_DCWL'] = (model_central_wlen - header_central_wlen,
                                            'Delta between model and header central_wavelength')

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -16,6 +16,7 @@ import itertools
 from importlib import import_module
 
 import matplotlib
+import numpy
 import numpy as np
 from astropy import units as u
 from astropy.io.ascii.core import InconsistentTableError
@@ -4005,7 +4006,7 @@ class Spect(Resample):
         log = self.log
         log.debug(gt.log_message("primitive", self.myself(), "starting"))
 
-        tocapture = ('c0', 'c1', 'c2', 'c3', 'rms')
+        tocapture = ('c0', 'c1', 'c2', 'c3', 'rms', 'fwidth')
 
         for ad in adinputs:
             for ext in ad:
@@ -4015,21 +4016,34 @@ class Spect(Resample):
 
                 for row in wavecal:
                     if row['name'] in tocapture:
-                        keyword = 'MWS_' + row['name'].upper()
+                        keyword = 'MWS_' + row['name'].upper()[:4]
                         ext.hdr[keyword] = (row['coefficients'],
                                             f'WAVECAL {row['name']} coefficient')
+                        if row['name'] == 'c0':
+                            # compare c0 with central_wavelength
+                            c0init = ext.central_wavelength(asNanometers=True)
+                            ext.hdr['MWS_C0DE'] = (row['coefficients'] - c0init,
+                                                   'Delta between c0 and central_wavelength')
+                        elif row['name'] == 'c1':
+                            # compare c1 with dispersion
 
-                # Get the wavelength of the central pixel
-                cp_x = ext.shape[0] / 2
-                cp_y = ext.shape[1] / 2
+                            # following waveval.py get_all_input_data
+                            dispaxis = 2 - ext.dispersion_axis()  # python sense
+                            center = int(0.5 * (ext.shape[1 - dispaxis] - 1))
+                            if dispaxis == 1:
+                                _slice = (center, slice(None))
+                            else:
+                                _slice = (slice(None), center)
+                            ndd = ext.nddata[_slice]
+                            npix = ndd.shape[0]
 
-                wcs_cent_nm = ext.wcs.pixel_to_world(cp_y, cp_x)[0].nm
-                hdr_cent_nm = ad.central_wavelength(asNanometers=True)
-                ext.hdr['MWS_WCS'] = (wcs_cent_nm, 'WCS solution central wavelength [nm]')
-                ext.hdr['MWS_HDR'] = (hdr_cent_nm, 'Header central wavelength [nm]')
-                ext.hdr['MWS_DIFF'] = (hdr_cent_nm - wcs_cent_nm,
-                                      'Difference between header and WCS central wavelengths')
+                            c1init = 0.5 * (npix - 1) * ext.dispersion(asNanometers=True)
+                            ext.hdr['MWS_C1DE'] = (row['coefficients'] - c1init,
+                                                   'Delta between c1 and 0.5*dispersion')
 
+                # Count the number of arc lines in the wavecal table
+                ext.hdr['MWS_NUML'] = (numpy.count_nonzero(wavecal['peaks']),
+                                       'Number of non-zero peaks in the WAVECAL table')
 
             ad.update_filename(suffix=params["suffix"], strip=True)
 

--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -4006,7 +4006,7 @@ class Spect(Resample):
         log = self.log
         log.debug(gt.log_message("primitive", self.myself(), "starting"))
 
-        tocapture = ('c0', 'c1', 'c2', 'c3', 'rms', 'fwidth')
+        tocapture = ('c0', 'c1', 'c2', 'c3', 'rms', 'inv_rms', 'fwidth')
 
         for ad in adinputs:
             for ext in ad:
@@ -4018,6 +4018,8 @@ class Spect(Resample):
                     # Capture values from WAVEVAL table into monitoring headers
                     if row['name'] in tocapture:
                         keyword = 'MWS_' + row['name'].upper()[:4]
+                        if row['name'] == 'inv_rms':
+                            keyword = 'MWS_IRMS'
                         ext.hdr[keyword] = (row['coefficients'],
                                             f'WAVECAL {row['name']} coefficient')
 

--- a/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
+++ b/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
@@ -19,5 +19,14 @@ def makeProcessedArc(p):
     p.storeProcessedArc()
     p.writeOutputs()
 
+def checkProcessedArc(p):
+    """
+    Extracts some values from the .WAVECAL extension for instrument monitoring
+    :param p:
+    :return:
+    """
+
+    p.monitorWavelengthSolution()
+    p.writeOutputs()
 
 _default = makeProcessedArc

--- a/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
+++ b/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
@@ -29,4 +29,23 @@ def checkProcessedArc(p):
     p.monitorWavelengthSolution()
     p.writeOutputs()
 
+def checkArc(p):
+    """
+    Reduce an arc, extract some values from the .WAVECAL extension for
+    instrument monitoring
+    :param p:
+    :return:
+    """
+    p.prepare(require_wcs=False)
+    p.addDQ()
+    p.addVAR(read_noise=True)
+    p.overscanCorrect()
+    p.ADUToElectrons()
+    p.addVAR(poisson_noise=True)
+    p.mosaicDetectors()
+    p.determineWavelengthSolution()
+    p.determineDistortion()
+    p.monitorWavelengthSolution()
+    p.writeOutputs()
+
 _default = makeProcessedArc

--- a/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
+++ b/geminidr/gmos/recipes/qa/recipes_ARC_LS_SPECT.py
@@ -36,6 +36,12 @@ def checkArc(p):
     :param p:
     :return:
     """
+    # In QA mode, if determineWavelengthSolution cannot find a good arc fit it
+    # uses a linear model based on the headers, whereas in SQ mode it raises an
+    # exception. For the purposes of checking arcs, we want everything to
+    # behave as if it is in SQ mode, so we just set that here
+    p.mode = 'sq'
+
     p.prepare(require_wcs=False)
     p.addDQ()
     p.addVAR(read_noise=True)
@@ -43,8 +49,11 @@ def checkArc(p):
     p.ADUToElectrons()
     p.addVAR(poisson_noise=True)
     p.mosaicDetectors()
-    p.determineWavelengthSolution()
-    p.determineDistortion()
+    # We force center=None to ensure it always gets the central row.
+    # This is the default anyway, but this prevents it being overridden.
+    p.determineWavelengthSolution(center=None)
+    # We don't need determineDistortion to check Arcs, and it's slow.
+    # p.determineDistortion()
     p.monitorWavelengthSolution()
     p.writeOutputs()
 


### PR DESCRIPTION
Adds a `monitorWavelengthSolution` primitive (alongside determineWavelengthSolution) in `primitives_spect.py` that extracts some values from the WAVECAL table for the GOA instrument monitoring system to capture. I'm amenable to this living somewhere else but being in the same file and where the values are calculated and the .WAVECAL added seemed to make more sense. Also open to name suggestions if people don't like it.

Adds GMOS qa recipes that use that primitive that can be run by GOA to generate Arc fit statistics.