### PR TITLE
Enh/embedded figures - adds a module in gempy/adlibrary to embed non-FITS files (PDFs etc) in astrodata instances and FITS files

### DIFF
--- a/geminidr/core/primitives_spect.py
+++ b/geminidr/core/primitives_spect.py
@@ -56,6 +56,7 @@ from gempy.library.fitting import fit_1D
 from gempy.library.matching import KDTreeFitter
 from gempy.library.nddops import NDStacker
 from gempy.library.spectral import Spek1D
+from gempy.adlibrary.embedded_files import embed_file
 from gwcs.utils import CoordinateFrameError
 from recipe_system.utils.decorators import parameter_override, capture_provenance
 from recipe_system.utils.md5 import md5sum
@@ -2933,6 +2934,9 @@ class Spect(Resample):
                     for fig in figures:
                         pdf.savefig(fig, bbox_inches='tight')
                     plt.close()
+
+                # We could add a parameter to enable this if desired
+                embed_file(ad, plot_filename, contenttype='pdf')
 
             # Timestamp and update the filename
             gt.mark_history(ad, primname=self.myself(), keyword=timestamp_key)

--- a/gempy/adlibrary/embedded_files.py
+++ b/gempy/adlibrary/embedded_files.py
@@ -1,0 +1,153 @@
+
+from astropy.io import fits
+import hashlib
+"""
+This hndles "embedding" files (eg PDFs) in the ad object so that they can be
+stored in the FITS file. We create a binary table attribute (tablename, which
+defaults to .FIGURES), which has columns for filename, Content-Type (ie mime 
+type), size, md5, and content, the latter of which is a varibale length binary 
+field which contains the actual contents of the file.
+
+This is useful for storing eg pdf figures generated during reduction inside
+the reduced data fits file, which is especially useful when the fits file is
+stored in the archive.
+
+This code is not especially memory efficient - multiple copies of the data
+may end up in memory. It is not intended for use with large files and will
+likely need refactoring if that use cases arises.
+"""
+
+def embed_file(ad, filename, contenttype, data=None, tablename='FIGURES'):
+    """
+    Embed a file in an astrodata instance.
+    :param ad: The ad instance to embed the file in
+    :param filename: Filename of the file to embed
+    :param contenttype: MIME type of the file
+    :param data: bytes or bytesarray of the actual binary file contents, or a
+    file-list object from which to read it from.
+    If NULL, filename will be opened and read
+    :param tablename: Name of the binary table attribute to store the file in.
+    Defaults to 'FIGURES'
+    :return: None
+    """
+
+    # Some convenience values are supported for contenttype:
+    contenttype = 'application/pdf' if contenttype.upper() == 'PDF' else contenttype
+    contenttype = 'image/png' if contenttype.upper() == 'PNG' else contenttype
+    contenttype = 'image/jpeg' if contenttype.upper() in ('JPG', 'JPEG') else contenttype
+
+    # If tablename already exists, read the columns into arrays
+    thdu = getattr(ad, tablename, None)
+    if thdu is not None:
+        filenames = thdu['filename'].tolist()
+        contenttypes = thdu['Content-Type'].tolist()
+        sizes = thdu['size'].tolist()
+        md5s = thdu['md5'].tolist()
+        contents = thdu['content'].tolist()
+    else:
+        # Initialize empty column arrays
+        filenames = []
+        contenttypes = []
+        sizes = []
+        md5s = []
+        contents = []
+
+    # Append the new file to the arrays
+    filenames.append(filename)
+    contenttypes.append(contenttype)
+
+    # If data None, read from the filename.
+    if data is None:
+        with open(filename, 'rb') as fp:
+            content = bytearray(fp.read())
+    # If data is a file-like, read from it
+    elif hasattr(data, 'read') and callable(data.read):
+        print("file like")
+        content = bytearray(data.read())
+        print(type(content))
+    elif isinstance(data, bytes):
+        print("bytes")
+        content = bytearray(data)
+    elif isinstance(data, bytearray):
+        print("bytearray")
+        content = data
+    else:
+        raise RuntimeError("Unknown data type in embed_file")
+
+    contents.append(content)
+    sizes.append(len(content))
+
+    h = hashlib.new('md5')
+    h.update(bytes(content))
+    md5s.append(h.hexdigest())
+
+    # Make a new table with the new arrays
+    col1 = fits.Column(name='filename', format='128A', array=filenames)
+    col2 = fits.Column(name='Content-Type', format='32A', array=contenttypes)
+    col3 = fits.Column(name='size', format='J', array=sizes)
+    col4 = fits.Column(name='md5', format='32A', array=md5s)
+    col5 = fits.Column(name='content', format='PB()',
+                       array=contents)
+    hdu = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5])
+    setattr(ad, tablename, hdu)
+
+def list_files(ad, fullinfo=False, tablename='FIGURES'):
+    """
+    List the files embedded in the astrodata instance
+    :param ad: the astrodata instance with files embedded
+    :param fullinfo: If False (default) return a list of filenames.
+    If True, return a list of dicts containing 'filename', 'size', 'Content-Type' and 'md5' keys
+    :param tablename: Name of the binary table attribute to store the file in.
+    :return: list or dict as above
+    """
+
+    hdu = getattr(ad, tablename)
+    retary = []
+
+    for row in hdu:
+        if fullinfo:
+            d = {}
+            for item in ('filename', 'size', 'Content-Type', 'md5'):
+                d[item] = row[item]
+            retary.append(d)
+        else:
+            retary.append(row['filename'])
+    return retary
+
+def extract_files(ad, todisk=True, filename=None, check=True, tablename='FIGURES'):
+    """
+    Extract files embedded in an astrodata instance
+    :param ad: astrodata instance to extract from
+    :param todisk: If True (default) write files to disk in current directory,
+    using the filenames specified when they were embedded. If False, return
+    a bytes instance with the content of the file.
+    :param filename: If there are multiple files embedded and you want only
+    one of them, give the filename here. If there are multiple files embedded
+    and you do not specify a filename and you specify todisk=False, an exception
+    will be raised
+    :param check: If True (default) raise an exception if the size or md5
+    does not match the content of the file.
+    :return: if todisk=True, returns a list of files writted to disk.
+    If todisk=False, returns the binary file content
+    """
+    hdu = getattr(ad, tablename)
+    retary = []
+    if len(hdu) > 1 and todisk is False and filename is None:
+        raise RuntimeError("Cannot extract multiple files not to disk")
+    for row in hdu:
+        if filename is None or row['filename'] == filename:
+            if check:
+                if len(row['content']) != row['size']:
+                    raise RuntimeError(f"File size mismatch for embedded file {row['filename']}")
+                h = hashlib.new('md5')
+                h.update(bytes(row['content']))
+                if h.hexdigest() != row['md5']:
+                    raise RuntimeError(f"MD5 mismatch for embedded file {row['filename']}")
+            if todisk:
+                with open(row['filename'], 'wb') as fp:
+                    fp.write(bytes(row['content']))
+                    retary.append(row['filename'])
+            else:
+                return bytes(row['content'])
+
+    return retary

--- a/gempy/adlibrary/tests/test_embedded_files.py
+++ b/gempy/adlibrary/tests/test_embedded_files.py
@@ -1,0 +1,110 @@
+import os
+
+import astrodata
+from gempy.adlibrary.embedded_files import embed_file, list_files, extract_files
+
+def test_embed_bytes():
+    ad = astrodata.AstroData()
+    assert hasattr(ad, 'FIGURES') is False
+
+    embed_file(ad, 'test.txt', contenttype='text/plain', data=b'abc')
+
+    assert hasattr(ad, 'FIGURES') is True
+    assert ad.FIGURES[0]['filename'] == 'test.txt'
+    assert ad.FIGURES[0]['Content-Type'] == 'text/plain'
+    assert ad.FIGURES[0]['size'] == 3
+    assert len(ad.FIGURES[0]['content']) ==  ad.FIGURES[0]['size']
+    assert ad.FIGURES[0]['md5'] =='900150983cd24fb0d6963f7d28e17f72'
+    assert bytes(ad.FIGURES[0]['content']) == b'abc'
+
+def test_tablename():
+    ad = astrodata.AstroData()
+    assert hasattr(ad, 'FOOBAR') is False
+
+    embed_file(ad, 'test.txt', tablename='FOOBAR',
+               contenttype='text/plain', data=b'abc')
+
+    assert hasattr(ad, 'FOOBAR') is True
+    assert ad.FOOBAR[0]['filename'] == 'test.txt'
+
+def test_embed_fp(tmp_path):
+    print("test embed fp")
+    # Make a temporary file
+    filename = tmp_path / 'file.dat'
+    with open(filename, 'wb') as fp:
+        fp.write(b"Hello, world")
+
+    ad = astrodata.AstroData()
+
+    # Open it again and embed the fp
+    with open(filename, 'rb') as fp:
+        embed_file(ad, 'file.dat', contenttype='text/plain', data=fp)
+
+    assert hasattr(ad, 'FIGURES') is True
+    assert ad.FIGURES[0]['filename'] == 'file.dat'
+    assert ad.FIGURES[0]['Content-Type'] == 'text/plain'
+    assert ad.FIGURES[0]['size'] == len("Hello, world")
+    assert len(ad.FIGURES[0]['content']) == ad.FIGURES[0]['size']
+    assert ad.FIGURES[0]['md5'] == 'bc6e6f16b8a077ef5fbc8d59d0b931b9'
+    assert bytes(ad.FIGURES[0]['content']) == b'Hello, world'
+
+def test_embed_from_file(tmp_path):
+    # Make a temporary file
+    filename = tmp_path / 'file.dat'
+    with open(filename, 'wb') as fp:
+        fp.write(b"Hello, world")
+
+    ad = astrodata.AstroData()
+
+    embed_file(ad, filename, contenttype='text/plain')
+
+    assert hasattr(ad, 'FIGURES') is True
+    assert ad.FIGURES[0]['filename'] == str(filename)
+    assert ad.FIGURES[0]['filename'].endswith('file.dat')
+    assert ad.FIGURES[0]['Content-Type'] == 'text/plain'
+    assert ad.FIGURES[0]['size'] == len("Hello, world")
+    assert len(ad.FIGURES[0]['content']) == ad.FIGURES[0]['size']
+    assert ad.FIGURES[0]['md5'] == 'bc6e6f16b8a077ef5fbc8d59d0b931b9'
+    assert bytes(ad.FIGURES[0]['content']) == b'Hello, world'
+
+def test_list_files():
+    ad = astrodata.AstroData()
+    embed_file(ad, 'a.txt', contenttype='text/plain', data=b'abc')
+    embed_file(ad, 'b.txt', contenttype='text/plain', data=b'defg')
+    embed_file(ad, 'c.txt', contenttype='text/plain', data=b'hijkl')
+
+    assert list_files(ad) == ['a.txt', 'b.txt', 'c.txt']
+
+    lod = list_files(ad, fullinfo=True)
+    a = lod[0]
+    b = lod[1]
+    c = lod[2]
+
+    assert a['filename'] == 'a.txt'
+    assert a['size'] == 3
+    assert a['md5'] == '900150983cd24fb0d6963f7d28e17f72'
+    assert a['Content-Type'] == 'text/plain'
+    assert b['filename'] == 'b.txt'
+    assert b['size'] == 4
+    assert c['filename'] == 'c.txt'
+    assert c['size'] == 5
+
+def test_extract_files(tmp_path):
+    ad = astrodata.AstroData()
+    embed_file(ad, 'a.txt', contenttype='text/plain', data=b'abc')
+    embed_file(ad, 'b.txt', contenttype='text/plain', data=b'defg')
+    embed_file(ad, 'c.txt', contenttype='text/plain', data=b'hijkl')
+
+    os.chdir(tmp_path)
+
+    extract_files(ad)
+
+    ld = os.listdir('.')
+    assert 'a.txt' in ld
+    assert 'b.txt' in ld
+    assert 'c.txt' in ld
+
+    with open('b.txt', 'rb') as fp:
+        b = fp.read()
+
+    assert b == b'defg'

--- a/gempy/scripts/extract_files
+++ b/gempy/scripts/extract_files
@@ -1,0 +1,1 @@
+extract_files.py

--- a/gempy/scripts/extract_files.py
+++ b/gempy/scripts/extract_files.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+#                                                                       DRAGONS
+#                                                                 gempy.scripts
+#                                                                    fixheader.py
+# -----------------------------------------------------------------------------
+"""
+This command will extract files that have been embedded within the FITS file
+using the gempy embedded_files module. This is typically used to capture PDF
+or other figures generated during data reduction and store them in the
+reduced data fits file.
+"""
+from argparse import ArgumentParser
+import textwrap
+import sys
+
+import astrodata
+from gempy import __version__
+
+from gempy.adlibrary.embedded_files import list_files, extract_files
+
+def main(args=None):
+    parser = ArgumentParser(
+        description=f"Embedded file extractor, v{__version__}",
+        epilog=textwrap.dedent(__doc__))
+    parser.add_argument("-v", "--version", action="version",
+                        version=f"v{__version__}")
+    parser.add_argument('--list', help="List embedded files, "
+                                     "as opposed to extracting them to disk",
+                        action='store_true')
+    parser.add_argument('filename', help='Fits file to extract from')
+
+    args = parser.parse_args(args)
+
+    ad = astrodata.open(args.filename)
+
+    if args.list:
+        for d in list_files(ad, fullinfo=True):
+            print(f"{d['filename']}: {d['Content-Type']}, {d['size']} bytes")
+    else:
+        for i in extract_files(ad):
+            print(f"Exracting: {i}")
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
There's been various discussions in the FITS community about storing non-FITS files (typically but not exclusively PDF / JPG / PNG graphics) inside FITS files. There are various ways to do this with various degrees of support. Consensus usually settles on storing the data in a binary table. 

This PR adds:
* an `embedded_files.py` module in `gempy/adlibrary` (with tests) to implement this. This allows capturing such files into an attribute of an astrodata instance and storing them as above in the corresponding FITS file. 
* an `extract_files[.py]` script in `gempy/scripts` to easily extract such files from their FITS containers.
* code in `geminidr/core/primitives_spect.py` to use the module to capture the arc PDF plot into the processed arc.

The way this is implemented the name of the ad attribute (that becomes the binary table FITS extension) defaults to `FIGURES` but the name can be specified in the call, and can contain multiple embedded files. There's nothing to stop adding multiple such attributes with different names. It uses variable length byte records to store the file contents, so does not waste space in the binary table if multiple files of different lengths are stored in the same attribute. The table also has columns for filename, size and md5sum to facilitate data integrity checking.

The implementation is simple, and due to the way FITS (and astropy) tables work, it not especially memory efficient for example when adding additional files to an existing table. This could be improved but the figures in question are usually small (~10s of K) compared to available memory so this is not an issue unless a use case arises to manipulate large data files using this mechanism