### PR TITLE
Use a shared conda env & file locking to avoid race conditions in CI testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,6 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
-                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests with Python 3.12"
                         sh 'tox -e py312-unit -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/unittests_results.xml ${TOX_ARGS}'
                         echo "Reportint coverage to CodeCov"
@@ -142,7 +141,6 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         echo "${env.PATH}"
-                        sh '.jenkins/scripts/setup_dirs.sh'
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Regression tests"
                         sh 'tox -e py312-reg -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/regression_results.xml ${TOX_ARGS}'
@@ -413,7 +411,6 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
-                        sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
                         sh 'tox -e py312-gmosls -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gmosls_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
@@ -451,7 +448,6 @@ pipeline {
                         echo "Running build #${env.BUILD_ID} on ${env.NODE_NAME}"
                         checkout scm
                         echo "${env.PATH}"
-                        sh '.jenkins/scripts/setup_dirs.sh'
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Slow tests"
                         sh 'tox -e py312-slow -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/slow_results.xml ${TOX_ARGS}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,10 +66,17 @@ pipeline {
                 echo "Update the Conda base install for all on-line nodes"
                 checkout scm
                 sh '.jenkins/scripts/setup_agent.sh'
-                echo "Create a shared Python 3.12 env"
-                sh 'tox -e py312-noop,codecov --workdir "${SHARED_TOX_DIR}" -v -r --notest'
-                echo "Install DRAGONS checkout to env, with cython_utils built"
-                sh '"${SHARED_TOX_DIR}/test_env/bin/python" -m pip install . --no-deps --ignore-installed --no-cache-dir -v'
+                // Install using a lock file (via file descriptor 200) to avoid
+                // different Jenkins runs updating conda's pkg cache at once:
+                echo "Create a shared Python 3.12 env & build+install DRAGONS"
+                sh '''
+                  LOCK_FILE="/tmp/jenkins_conda.lock"
+                  (
+                    flock --exclusive --timeout 900 200 || { echo "Failed to acquire lock after 900s"; exit 1; }
+                    tox -e py312-noop,codecov --workdir "${SHARED_TOX_DIR}" -v -r --notest
+                    "${SHARED_TOX_DIR}/test_env/bin/python" -m pip install . --no-deps --ignore-installed --no-cache-dir -v
+                  ) 200>"$LOCK_FILE"
+                '''
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
     environment {
         MPLBACKEND = "agg"
         PATH = "$JENKINS_CONDA_HOME/bin:$PATH"
+        SHARED_TOX_DIR = "${env.WORKSPACE}/tox_shared"
     }
 
     stages {
@@ -65,8 +66,10 @@ pipeline {
                 echo "Update the Conda base install for all on-line nodes"
                 checkout scm
                 sh '.jenkins/scripts/setup_agent.sh'
-                echo "Create a trial Python 3.12 env, to cache new packages"
-                sh 'tox -e py312-noop -v -r -- --basetemp=${DRAGONS_TEST_OUT} ${TOX_ARGS}'
+                echo "Create a shared Python 3.12 env"
+                sh 'tox -e py312-noop,codecov --workdir "${SHARED_TOX_DIR}" -v -r --notest'
+                echo "Install DRAGONS checkout to env, with cython_utils built"
+                sh '"${SHARED_TOX_DIR}/test_env/bin/python" -m pip install . --no-deps --ignore-installed --no-cache-dir -v'
             }
             post {
                 always {
@@ -101,9 +104,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests with Python 3.12"
-                        sh 'tox -e py312-unit -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/unittests_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-unit --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/unittests_results.xml ${TOX_ARGS}'
                         echo "Reportint coverage to CodeCov"
-                        sh 'tox -e codecov -- -F unit'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F unit'
                     }
                     post {
                         always {
@@ -143,9 +146,9 @@ pipeline {
                         echo "${env.PATH}"
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Regression tests"
-                        sh 'tox -e py312-reg -v -r -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/regression_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-reg --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/regression_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F regression'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F regression'
                     } // end steps
                     post {
                         always {
@@ -179,9 +182,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-wavecal -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/wavecal_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-wavecal --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/wavecal_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F wavecal'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F wavecal'
                     }  // end steps
                     post {
                         always {
@@ -222,9 +225,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-f2 -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/f2_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-f2 --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/f2_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F f2'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F f2'
                     }  // end steps
                     post {
                         always {
@@ -259,9 +262,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-gsaoi -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gsaoi_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-gsaoi --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/gsaoi_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F gsaoi'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F gsaoi'
                     }  // end steps
                     post {
                         always {
@@ -296,9 +299,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-niri -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/niri_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-niri --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/niri_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F niri'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F niri'
                     }  // end steps
                     post {
                         always {
@@ -333,9 +336,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-gnirs -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gnirs_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-gnirs --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/gnirs_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F gnirs'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F gnirs'
                     }  // end steps
                     post {
                         always {
@@ -370,9 +373,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-gmos -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gmos_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-gmos --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/gmos_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F gmos'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F gmos'
                     }  // end steps
                     post {
                         always {
@@ -412,9 +415,9 @@ pipeline {
                         checkout scm
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Running tests"
-                        sh 'tox -e py312-gmosls -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/gmosls_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-gmosls --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/gmosls_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F gmosls'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F gmosls'
                     }  // end steps
                     post {
                         always {
@@ -450,9 +453,9 @@ pipeline {
                         echo "${env.PATH}"
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "Slow tests"
-                        sh 'tox -e py312-slow -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/slow_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-slow --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/slow_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F slow'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F slow'
                     } // end steps
                     post {
                         always {
@@ -487,9 +490,9 @@ pipeline {
                         echo "${env.PATH}"
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "GHOST tests"
-                        sh 'tox -e py312-ghost -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/ghost_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-ghost --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/ghost_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F ghost'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F ghost'
                     } // end steps
                     post {
                         always {
@@ -524,9 +527,9 @@ pipeline {
                         echo "${env.PATH}"
                         sh '.jenkins/scripts/setup_dirs.sh'
                         echo "GHOST tests"
-                        sh 'tox -e py312-ghost_integ -v -- --basetemp=${DRAGONS_TEST_OUT} --junit-xml reports/ghost_integ_results.xml ${TOX_ARGS}'
+                        sh 'tox -e py312-ghost_integ --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -v -- --basetemp="${DRAGONS_TEST_OUT}" --junit-xml reports/ghost_integ_results.xml ${TOX_ARGS}'
                         echo "Reporting coverage"
-                        sh 'tox -e codecov -- -F ghost_integ'
+                        sh 'tox -e codecov --workdir "${SHARED_TOX_DIR}" --skip-pkg-install -- -F ghost_integ'
                     } // end steps
                     post {
                         always {

--- a/tox.ini
+++ b/tox.ini
@@ -55,10 +55,8 @@ conda_channels =
     conda-forge
 conda_create_args =
     --override-channels
-    --experimental=lock
 conda_install_args =
     --override-channels
-    --experimental=lock
 extras =
     test
     docs: docs

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ conda_deps =
     specutils>=2.0
     sqlalchemy>=2.0.0
     typing_extensions>=4.9
+    wheel
 conda_channels =
     http://astroconda.gemini.edu/public
     conda-forge
@@ -64,6 +65,7 @@ extras =
 deps =
     git+https://github.com/GeminiDRSoftware/FitsStorage.git@v3.6.2
     git+https://github.com/GeminiDRSoftware/pytest_dragons.git@v1.0.7#egg=pytest_dragons
+    git+https://github.com/GeminiDRSoftware/AstroFaker
 changedir =
     .tmp
 commands =
@@ -71,8 +73,6 @@ commands =
     which python
     which pip
     which pytest
-    pip install wheel
-    pip install git+https://github.com/GeminiDRSoftware/AstroFaker
     conda list
     noop: python -c "pass"  # just install deps & ensure python runs
     unit: python -m coverage run --rcfile={toxinidir}/.coveragerc -m pytest -v --dragons-remote-data --durations=20 -m "not integration_test and not gmos and not gmosls and not gmosimage and not f2 and not f2ls and not f2image and not gsaoi and not niri and not nirils and not niriimage and not gnirs and not gnirsls and not gnirsimage and not gnirsxd and not wavecal and not regression and not slow and not ghost and not ghostbundle and not ghostslit and not ghostspect" {posargs:astrodata geminidr gemini_instruments gempy recipe_system}

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ requires = tox-conda
 isolated_build = true
 
 [testenv]
+envdir = {toxworkdir}/test_env
 args_are_paths = false
 whitelist_externals =
     which
@@ -95,6 +96,7 @@ deps = coverage
 commands = coverage {posargs:report}
 
 [testenv:codecov]
+envdir = {toxworkdir}/codecov_env
 skip_install = true
 passenv = CI JENKINS_* CODECOV_TOKEN
 conda_deps =


### PR DESCRIPTION
Recently, we have started seeing more obscure, conda-cache-related failures in Jenkins. We had been provisionally working around these issues with some experimental locking flags in conda (amongst other measures), but those are being deprecated in the latest conda (which is also reported by AI to update cache more aggressively) and seem to have become less reliable, so it was time for a more definitive solution.

After trying 2-3 slightly different approaches, this PR primarily implements the following, relatively simple changes when testing with Jenkins & tox:

* Remove deprecated locking flags from conda create/install arguments.
* Define a shared tox directory & shared conda env subdirs to be used by all test stages (instead of having 12+ separate installations under the working directories for each test).
* Tell tox to use the shared envs and refrain from (re)installing packages in parallel test stages.
* Install DRAGONS checkout into the test env explicitly (building `cython_utils` in the process), so the test stages can still find it.
* Move AstroFaker installation out of the test commands into the main dependencies, to avoid collisions due to repeated installs.
* Use file locking when running the conda + DRAGONS pre-install step, to avoid collisions between separate Jenkins runs trying to update the conda cache (or other files in common).

This also speeds up test runs by something like 15 minutes and reduces the scope for network-related failures by avoiding repeated ~5-minute installs in 4 sequential blocks.

Next time we work on this, we should probably switch to using tox 4 (or nox) with `pyproject.toml`, eliminating our dependence on the no-longer-supported tox 3 and consolidating our dependency lists from `tox.ini` & `setup.py`. This would also allow using some newer options/variables for better control over the process.