### PR TITLE
move test_adding_longslit_wcs out of astrodata and into gempy/library

### DIFF
--- a/astrodata/tests/test_wcs.py
+++ b/astrodata/tests/test_wcs.py
@@ -8,14 +8,14 @@ from astropy.modeling import models
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
 from astropy import units as u
-from astropy.io.fits import Header
+#from astropy.io.fits import Header
 from gwcs import coordinate_frames as cf
 from gwcs.wcs import WCS as gWCS
 
 import astrodata
 from astrodata import wcs as adwcs
 from astrodata.testing import download_from_archive
-from gempy.library.transform import add_longslit_wcs
+#from gempy.library.transform import add_longslit_wcs
 
 
 @pytest.fixture(scope='module')
@@ -164,43 +164,43 @@ def test_gwcs_creation(NIRI_IMAGE):
             assert wcs_sky.separation(gwcs_sky) < 0.01 * u.arcsec
 
 
-@pytest.mark.dragons_remote_data
-def test_adding_longslit_wcs(GMOS_LONGSLIT):
-    """Test that adding the longslit WCS doesn't interfere with the sky
-    coordinates of the WCS"""
-    ad = astrodata.open(GMOS_LONGSLIT)
-    frame_name = ad[4].hdr.get("RADESYS", ad[4].hdr["RADECSYS"]).lower()
-    crpix1 = ad[4].hdr["CRPIX1"] - 1
-    crpix2 = ad[4].hdr["CRPIX2"] - 1
-    gwcs_sky = SkyCoord(*ad[4].wcs(crpix1, crpix2), unit=u.deg, frame=frame_name)
-    add_longslit_wcs(ad)
-    gwcs_coords = ad[4].wcs(crpix1, crpix2)
-    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
-    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
-    # The sky coordinates should not depend on the x pixel value
-    gwcs_coords = ad[4].wcs(0, crpix2)
-    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
-    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
-
-    # The sky coordinates also should not depend on the extension
-    # there are shifts of order 1 pixel because of the rotations of CCDs 1
-    # and 3, which are incorporated into their raw WCSs. Remember that the
-    # 12 WCSs are independent at this stage, they don't all map onto the
-    # WCS of the reference extension
-    for ext in ad:
-        gwcs_coords = ext.wcs(0, crpix2)
-        new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
-        assert gwcs_sky.separation(new_gwcs_sky) < 0.1 * u.arcsec
-
-    # This is equivalent to writing to disk and reading back in
-    wcs_dict = astrodata.wcs.gwcs_to_fits(ad[4].nddata, ad.phu)
-    new_gwcs = astrodata.wcs.fitswcs_to_gwcs(Header(wcs_dict))
-    gwcs_coords = new_gwcs(crpix1, crpix2)
-    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
-    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
-    gwcs_coords = new_gwcs(0, crpix2)
-    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
-    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+# @pytest.mark.dragons_remote_data
+# def test_adding_longslit_wcs(GMOS_LONGSLIT):
+#     """Test that adding the longslit WCS doesn't interfere with the sky
+#     coordinates of the WCS"""
+#     ad = astrodata.open(GMOS_LONGSLIT)
+#     frame_name = ad[4].hdr.get("RADESYS", ad[4].hdr["RADECSYS"]).lower()
+#     crpix1 = ad[4].hdr["CRPIX1"] - 1
+#     crpix2 = ad[4].hdr["CRPIX2"] - 1
+#     gwcs_sky = SkyCoord(*ad[4].wcs(crpix1, crpix2), unit=u.deg, frame=frame_name)
+#     add_longslit_wcs(ad)
+#     gwcs_coords = ad[4].wcs(crpix1, crpix2)
+#     new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+#     assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+#     # The sky coordinates should not depend on the x pixel value
+#     gwcs_coords = ad[4].wcs(0, crpix2)
+#     new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+#     assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+#
+#     # The sky coordinates also should not depend on the extension
+#     # there are shifts of order 1 pixel because of the rotations of CCDs 1
+#     # and 3, which are incorporated into their raw WCSs. Remember that the
+#     # 12 WCSs are independent at this stage, they don't all map onto the
+#     # WCS of the reference extension
+#     for ext in ad:
+#         gwcs_coords = ext.wcs(0, crpix2)
+#         new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+#         assert gwcs_sky.separation(new_gwcs_sky) < 0.1 * u.arcsec
+#
+#     # This is equivalent to writing to disk and reading back in
+#     wcs_dict = astrodata.wcs.gwcs_to_fits(ad[4].nddata, ad.phu)
+#     new_gwcs = astrodata.wcs.fitswcs_to_gwcs(Header(wcs_dict))
+#     gwcs_coords = new_gwcs(crpix1, crpix2)
+#     new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+#     assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+#     gwcs_coords = new_gwcs(0, crpix2)
+#     new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+#     assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
 
 # Coordinates of projection center and new projection center
 @pytest.mark.parametrize("coords", ([(0, 0), (0.1, -0.1)],

--- a/gempy/library/tests/test_transform.py
+++ b/gempy/library/tests/test_transform.py
@@ -1,11 +1,26 @@
 import pytest
 
 from astropy.modeling import models
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+from astropy.io.fits import Header
 
 import numpy as np
 from geminidr.gmos.primitives_gmos_image import GMOSImage
 from gempy.library import transform
 from geminidr.gmos.lookups import geometry_conf as geotable
+
+# TODO: Either remove astrodata dependency or move the
+# transform module to gempy/adlibrary.  That includes all
+# the functions that accept an AD object as input, not just
+# the need to import astrodata.
+import astrodata
+from astrodata.testing import download_from_archive
+
+@pytest.fixture(scope='module')
+def GMOS_LONGSLIT():
+    """Any GMOS longslit spectrum"""
+    return download_from_archive("N20180103S0332.fits")
 
 @models.custom_model
 def InverseQuadratic1D(x, c0=0, c1=0, c2=0):
@@ -131,3 +146,42 @@ def test_2d_nonaffine_transform():
          for i in range(1, size-1) for j in range(1, size-1)]
     assert np.allclose(x[1:-1, 1:-1], np.array(y).reshape(size-2, size-2),
                        rtol=0.03, atol=0.2)
+
+
+@pytest.mark.dragons_remote_data
+def test_adding_longslit_wcs(GMOS_LONGSLIT):
+    """Test that adding the longslit WCS doesn't interfere with the sky
+    coordinates of the WCS"""
+    ad = astrodata.open(GMOS_LONGSLIT)
+    frame_name = ad[4].hdr.get("RADESYS", ad[4].hdr["RADECSYS"]).lower()
+    crpix1 = ad[4].hdr["CRPIX1"] - 1
+    crpix2 = ad[4].hdr["CRPIX2"] - 1
+    gwcs_sky = SkyCoord(*ad[4].wcs(crpix1, crpix2), unit=u.deg, frame=frame_name)
+    transform.add_longslit_wcs(ad)
+    gwcs_coords = ad[4].wcs(crpix1, crpix2)
+    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+    # The sky coordinates should not depend on the x pixel value
+    gwcs_coords = ad[4].wcs(0, crpix2)
+    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+
+    # The sky coordinates also should not depend on the extension
+    # there are shifts of order 1 pixel because of the rotations of CCDs 1
+    # and 3, which are incorporated into their raw WCSs. Remember that the
+    # 12 WCSs are independent at this stage, they don't all map onto the
+    # WCS of the reference extension
+    for ext in ad:
+        gwcs_coords = ext.wcs(0, crpix2)
+        new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+        assert gwcs_sky.separation(new_gwcs_sky) < 0.1 * u.arcsec
+
+    # This is equivalent to writing to disk and reading back in
+    wcs_dict = astrodata.wcs.gwcs_to_fits(ad[4].nddata, ad.phu)
+    new_gwcs = astrodata.wcs.fitswcs_to_gwcs(Header(wcs_dict))
+    gwcs_coords = new_gwcs(crpix1, crpix2)
+    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec
+    gwcs_coords = new_gwcs(0, crpix2)
+    new_gwcs_sky = SkyCoord(*gwcs_coords[1:], unit=u.deg, frame=frame_name)
+    assert gwcs_sky.separation(new_gwcs_sky) < 0.01 * u.arcsec


### PR DESCRIPTION
Move a test that imports gempy out of astrodata and into gempy where the function being tested lives.