### PR TITLE
Explicitly install pip in the unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Install packages
         shell: bash -l {0}
-        run: python -m pip install tox tox-conda
+        run: |
+          python -m ensurepip
+          python -m pip install tox tox-conda
 
       - name: Setup DRAGONS_TEST
         shell: bash -l {0}

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ conda_deps =
     numpy>=1.24
     objgraph>=3.5
     pandas>=2.0
+    pip
     psutil>=5.6  # only used by adcc?
     pyerfa>=1.7
     pytest>=5.2


### PR DESCRIPTION
Maybe pip used to be installed automatically by conda but it isn't anymore.   Explicitly ensure that pip is installed before continuing.