### PR TITLE
Move get_associated_calibration out of astrodata.

### DIFF
--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -7,7 +7,6 @@ import shutil
 import urllib
 import hashlib
 import requests
-import xml.etree.ElementTree as et
 
 import numpy as np
 import pytest
@@ -280,34 +279,6 @@ def download_from_archive(filename, sub_path='raw_files', env_var='DRAGONS_TEST'
         os.chmod(local_path, 0o664)
 
     return local_path
-
-
-def get_associated_calibrations(filename, nbias=5):
-    """
-    Queries Gemini Observatory Archive for associated calibrations to reduce
-    the data that will be used for testing.
-
-    Parameters
-    ----------
-    filename : str
-        Input file name
-    """
-    url = f"https://archive.gemini.edu/calmgr/{filename}"
-    tree = et.parse(urllib.request.urlopen(url))
-    root = tree.getroot()
-    prefix = root.tag[:root.tag.rfind('}') + 1]
-
-    rows = []
-    for node in tree.iter(prefix + 'calibration'):
-        cal_type = node.find(prefix + 'caltype').text
-        cal_filename = node.find(prefix + 'filename').text
-        if not ('processed_' in cal_filename or 'specphot' in cal_filename):
-            rows.append((cal_filename, cal_type))
-
-    tbl = Table(rows=rows, names=['filename', 'caltype'])
-    tbl.sort('filename')
-    tbl.remove_rows(np.where(tbl['caltype'] == 'bias')[0][nbias:])
-    return tbl
 
 
 class ADCompare:

--- a/astrodata/testing.py
+++ b/astrodata/testing.py
@@ -4,7 +4,6 @@ Fixtures to be used in tests in DRAGONS
 
 import os
 import shutil
-import urllib
 import hashlib
 import requests
 

--- a/recipe_system/testing.py
+++ b/recipe_system/testing.py
@@ -1,13 +1,43 @@
 import os
 import pytest
+import xml.etree.ElementTree as et
+
+from astropy.table import Table
 
 import astrodata
 import gemini_instruments
 
-from astrodata import testing
 from gempy.utils import logutils
 from recipe_system.reduction.coreReduce import Reduce
 from recipe_system.utils.reduce_utils import normalize_ucals
+
+
+def _get_associated_calibrations(filename, nbias=5):
+    """
+    Queries Gemini Observatory Archive for associated calibrations to reduce
+    the data that will be used for testing.
+
+    Parameters
+    ----------
+    filename : str
+        Input file name
+    """
+    url = f"https://archive.gemini.edu/calmgr/{filename}"
+    tree = et.parse(urllib.request.urlopen(url))
+    root = tree.getroot()
+    prefix = root.tag[:root.tag.rfind('}') + 1]
+
+    rows = []
+    for node in tree.iter(prefix + 'calibration'):
+        cal_type = node.find(prefix + 'caltype').text
+        cal_filename = node.find(prefix + 'filename').text
+        if not ('processed_' in cal_filename or 'specphot' in cal_filename):
+            rows.append((cal_filename, cal_type))
+
+    tbl = Table(rows=rows, names=['filename', 'caltype'])
+    tbl.sort('filename')
+    tbl.remove_rows(np.where(tbl['caltype'] == 'bias')[0][nbias:])
+    return tbl
 
 
 @pytest.fixture(scope='module')
@@ -32,7 +62,7 @@ def get_master_arc(path_to_inputs, change_working_dir):
 
     def _get_master_arc(ad, pre_process):
 
-        cals = testing.get_associated_calibrations(
+        cals = _get_associated_calibrations(
             ad.filename.split('_')[0] + '.fits')
 
         arc_filename = cals[cals['caltype'] == 'arc']['filename'][0]

--- a/recipe_system/testing.py
+++ b/recipe_system/testing.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import urllib
 import xml.etree.ElementTree as et
 
 from astropy.table import Table


### PR DESCRIPTION
DRAGONS does not expect it to be there anymore.  It has been moved to the one module that needs it.